### PR TITLE
fix: naming convention

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,7 +110,7 @@ def create_vault(project, gov, fee_manager):
         # set up fee manager
         vault.setFeeManager(fee_manager.address, sender=gov)
 
-        vault.set_role(
+        vault.setRole(
             gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov
         )
 
@@ -149,6 +149,7 @@ def create_lossy_strategy(project, strategist):
 @pytest.fixture(scope="session")
 def vault(gov, asset, create_vault):
     vault = create_vault(asset)
+    vault.setRole(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
     yield vault
 
 

--- a/tests/e2e/test_strategy_withdraw_flow.py
+++ b/tests/e2e/test_strategy_withdraw_flow.py
@@ -30,7 +30,7 @@ def test_multiple_strategy_withdraw_flow(
     actions.user_deposit(whale, vault, asset, whale_amount)
 
     # set up strategies
-    vault.set_role(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
+    vault.setRole(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
     for strategy in strategies:
         actions.add_strategy_to_vault(gov, strategy, vault)
 

--- a/tests/unit/periphery/test_fee_manager.py
+++ b/tests/unit/periphery/test_fee_manager.py
@@ -6,7 +6,7 @@ from utils.constants import ZERO_ADDRESS
 def test_deploy_fee_manager(project, gov):
     fee_manager = gov.deploy(project.FeeManager)
 
-    assert fee_manager.fee_manager() == gov
+    assert fee_manager.feeManager() == gov
 
 
 def test_distribute(gov, bunny, vault, fee_manager):
@@ -31,13 +31,13 @@ def test_distribute(gov, bunny, vault, fee_manager):
 def test_set_performance_fee__with_valid_performance_fee(
     gov, vault, fee_manager, performance_fee
 ):
-    tx = fee_manager.set_performance_fee(vault.address, performance_fee, sender=gov)
+    tx = fee_manager.setPerformanceFee(vault.address, performance_fee, sender=gov)
     event = list(tx.decode_logs(fee_manager.UpdatePerformanceFee))
 
     assert len(event) == 1
-    assert event[0].performance_fee == performance_fee
+    assert event[0].performanceFee == performance_fee
 
-    assert fee_manager.fees(vault).performance_fee == performance_fee
+    assert fee_manager.fees(vault).performanceFee == performance_fee
 
 
 def test_set_performance_fee_with_invalid_performance_fee_reverts(
@@ -47,12 +47,12 @@ def test_set_performance_fee_with_invalid_performance_fee_reverts(
     invalid_performance_fee = 5001
 
     with ape.reverts("not fee manager"):
-        fee_manager.set_performance_fee(
+        fee_manager.setPerformanceFee(
             vault.address, valid_performance_fee, sender=bunny
         )
 
     with ape.reverts("exceeds performance fee threshold"):
-        fee_manager.set_performance_fee(
+        fee_manager.setPerformanceFee(
             vault.address, invalid_performance_fee, sender=gov
         )
 
@@ -61,13 +61,13 @@ def test_set_performance_fee_with_invalid_performance_fee_reverts(
 def test_management_fee__with_valid_management_fee(
     gov, vault, fee_manager, management_fee
 ):
-    tx = fee_manager.set_management_fee(vault.address, management_fee, sender=gov)
+    tx = fee_manager.setManagementFee(vault.address, management_fee, sender=gov)
     event = list(tx.decode_logs(fee_manager.UpdateManagementFee))
 
     assert len(event) == 1
-    assert event[0].management_fee == management_fee
+    assert event[0].managementFee == management_fee
 
-    assert fee_manager.fees(vault).management_fee == management_fee
+    assert fee_manager.fees(vault).managementFee == management_fee
 
 
 def test_management_fee__with_invalid_management_fee_reverts(
@@ -77,44 +77,40 @@ def test_management_fee__with_invalid_management_fee_reverts(
     invalid_management_fee = 10001
 
     with ape.reverts("not fee manager"):
-        fee_manager.set_management_fee(
-            vault.address, valid_management_fee, sender=bunny
-        )
+        fee_manager.setManagementFee(vault.address, valid_management_fee, sender=bunny)
 
     with ape.reverts("exceeds management fee threshold"):
-        fee_manager.set_management_fee(
-            vault.address, invalid_management_fee, sender=gov
-        )
+        fee_manager.setManagementFee(vault.address, invalid_management_fee, sender=gov)
 
 
 def test_commit_fee_manager__with_new_fee_manager(gov, bunny, fee_manager):
     with ape.reverts("not fee manager"):
-        fee_manager.commit_fee_manager(bunny.address, sender=bunny)
+        fee_manager.commitFeeManager(bunny.address, sender=bunny)
 
-    tx = fee_manager.commit_fee_manager(bunny.address, sender=gov)
+    tx = fee_manager.commitFeeManager(bunny.address, sender=gov)
     event = list(tx.decode_logs(fee_manager.CommitFeeManager))
 
     assert len(event) == 1
-    assert event[0].fee_manager == bunny.address
+    assert event[0].feeManager == bunny.address
 
-    assert fee_manager.future_fee_manager() == bunny.address
+    assert fee_manager.futureFeeManager() == bunny.address
 
 
 def test_apply_fee_manager__with_new_fee_manager(gov, bunny, fee_manager):
-    fee_manager.commit_fee_manager(ZERO_ADDRESS, sender=gov)
+    fee_manager.commitFeeManager(ZERO_ADDRESS, sender=gov)
 
     with ape.reverts("not fee manager"):
-        fee_manager.apply_fee_manager(sender=bunny)
+        fee_manager.applyFeeManager(sender=bunny)
 
     with ape.reverts("future fee manager != zero address"):
-        fee_manager.apply_fee_manager(sender=gov)
+        fee_manager.applyFeeManager(sender=gov)
 
-    fee_manager.commit_fee_manager(bunny.address, sender=gov)
+    fee_manager.commitFeeManager(bunny.address, sender=gov)
 
-    tx = fee_manager.apply_fee_manager(sender=gov)
+    tx = fee_manager.applyFeeManager(sender=gov)
     event = list(tx.decode_logs(fee_manager.ApplyFeeManager))
 
     assert len(event) == 1
-    assert event[0].fee_manager == bunny.address
+    assert event[0].feeManager == bunny.address
 
-    assert fee_manager.fee_manager() == bunny.address
+    assert fee_manager.feeManager() == bunny.address

--- a/tests/unit/vault/test_erc4626.py
+++ b/tests/unit/vault/test_erc4626.py
@@ -122,7 +122,7 @@ def test_max_withdraw__with_balance_greater_than_total_idle__returns_total_idle(
     strategy_deposit = assets // 2
     total_idle = assets - strategy_deposit
 
-    vault.set_role(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
+    vault.setRole(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
     actions.user_deposit(fish, vault, asset, assets)
     actions.add_strategy_to_vault(gov, strategy, vault)
     actions.add_debt_to_strategy(gov, strategy, vault, strategy_deposit)
@@ -161,7 +161,7 @@ def test_max_redeem__with_balance_greater_than_total_idle__returns_total_idle(
     strategy_deposit = assets // 2
     total_idle = assets - strategy_deposit
 
-    vault.set_role(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
+    vault.setRole(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
     actions.user_deposit(fish, vault, asset, assets)
     actions.add_strategy_to_vault(gov, strategy, vault)
     actions.add_debt_to_strategy(gov, strategy, vault, strategy_deposit)

--- a/tests/unit/vault/test_roles.py
+++ b/tests/unit/vault/test_roles.py
@@ -3,12 +3,12 @@ from utils import actions, checks
 from utils.constants import MAX_INT, ROLES
 
 
-def test_set_role(gov, fish, asset, create_vault):
+def test_setRole(gov, fish, asset, create_vault):
     vault = create_vault(asset)
-    vault.set_role(fish.address, ROLES.DEBT_MANAGER, sender=gov)
+    vault.setRole(fish.address, ROLES.DEBT_MANAGER, sender=gov)
 
     with ape.reverts():
-        vault.set_role(fish.address, ROLES.DEBT_MANAGER, sender=fish)
+        vault.setRole(fish.address, ROLES.DEBT_MANAGER, sender=fish)
 
     with ape.reverts():
-        vault.set_role(fish.address, 100, sender=fish)
+        vault.setRole(fish.address, 100, sender=fish)

--- a/tests/unit/vault/test_strategy_withdraw.py
+++ b/tests/unit/vault/test_strategy_withdraw.py
@@ -14,7 +14,7 @@ def test_withdraw__with_inactive_strategy__reverts(
     inactive_strategy = create_strategy(vault)
     strategies = [inactive_strategy]
 
-    vault.set_role(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
+    vault.setRole(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
     actions.user_deposit(fish, vault, asset, amount)
     actions.add_strategy_to_vault(gov, strategy, vault)
     actions.add_debt_to_strategy(gov, strategy, vault, amount)
@@ -38,7 +38,7 @@ def test_withdraw__with_insufficient_funds_in_strategies__reverts(
     strategy = create_strategy(vault)
     strategies = []  # do not pass in any strategies
 
-    vault.set_role(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
+    vault.setRole(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
     actions.user_deposit(fish, vault, asset, amount)
     actions.add_strategy_to_vault(gov, strategy, vault)
     actions.add_debt_to_strategy(gov, strategy, vault, amount)
@@ -62,7 +62,7 @@ def test_withdraw__with_liquid_strategy_only__withdraws(
     strategy = create_strategy(vault)
     strategies = [strategy]
 
-    vault.set_role(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
+    vault.setRole(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
     actions.user_deposit(fish, vault, asset, amount)
     actions.add_strategy_to_vault(gov, strategy, vault)
     actions.add_debt_to_strategy(gov, strategy, vault, amount)
@@ -100,7 +100,7 @@ def test_withdraw__with_multiple_liquid_strategies__withdraws(
     actions.user_deposit(fish, vault, asset, amount)
 
     # set up strategies
-    vault.set_role(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
+    vault.setRole(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
     for strategy in strategies:
         actions.add_strategy_to_vault(gov, strategy, vault)
         actions.add_debt_to_strategy(gov, strategy, vault, amount_per_strategy)
@@ -141,7 +141,7 @@ def test_withdraw__with_locked_and_liquid_strategy__withdraws(
     actions.user_deposit(fish, vault, asset, amount)
 
     # set up strategies
-    vault.set_role(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
+    vault.setRole(gov.address, ROLES.STRATEGY_MANAGER | ROLES.DEBT_MANAGER, sender=gov)
     for strategy in strategies:
         actions.add_strategy_to_vault(gov, strategy, vault)
         actions.add_debt_to_strategy(gov, strategy, vault, amount_per_strategy)

--- a/tests/utils/actions.py
+++ b/tests/utils/actions.py
@@ -29,5 +29,5 @@ def add_debt_to_strategy(user, strategy, vault, max_debt: int):
 
 
 def set_fees_for_strategy(gov, strategy, fee_manager, management_fee, performance_fee):
-    fee_manager.set_management_fee(strategy.address, management_fee, sender=gov)
-    fee_manager.set_performance_fee(strategy.address, performance_fee, sender=gov)
+    fee_manager.setManagementFee(strategy.address, management_fee, sender=gov)
+    fee_manager.setPerformanceFee(strategy.address, performance_fee, sender=gov)


### PR DESCRIPTION
## Description

Use camel case instead of snake case for vyper. Snake case remain used for constants and internal function prefix.

Fixes # (issue)

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
