### PR TITLE
fix: tweaks

### DIFF
--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -31,9 +31,12 @@ abstract contract BaseStrategy {
         asset = IVault(vault).asset();
     }
 
-    function maxDeposit(
-        address receiver
-    ) public view virtual returns (uint256 maxAssets) {
+    function maxDeposit(address receiver)
+        public
+        view
+        virtual
+        returns (uint256 maxAssets)
+    {
         if (receiver == vault) {
             maxAssets = type(uint256).max;
         } else {
@@ -62,10 +65,11 @@ abstract contract BaseStrategy {
         return 0;
     }
 
-    function deposit(
-        uint256 assets,
-        address receiver
-    ) public onlyVault returns (uint256) {
+    function deposit(uint256 assets, address receiver)
+        public
+        onlyVault
+        returns (uint256)
+    {
         // transfer and invest
         IERC20(asset).transferFrom(msg.sender, address(this), assets);
         _invest();
@@ -100,13 +104,16 @@ abstract contract BaseStrategy {
         return amountWithdrawn;
     }
 
-    function _maxWithdraw(
-        address owner
-    ) internal view virtual returns (uint256 withdrawAmount);
+    function _maxWithdraw(address owner)
+        internal
+        view
+        virtual
+        returns (uint256 withdrawAmount);
 
-    function _withdraw(
-        uint256 amount
-    ) internal virtual returns (uint256 withdrawnAmount);
+    function _withdraw(uint256 amount)
+        internal
+        virtual
+        returns (uint256 withdrawnAmount);
 
     function _invest() internal virtual;
 

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -289,13 +289,11 @@ def _burn_unlocked_shares():
   """
   unlocked_shares: uint256 = self._unlocked_shares()
   if unlocked_shares == 0:
-    return 0
+    return
   
   # update variables (done here to keep _unlocked_shares() as a view function)
   if self.full_profit_unlock_date > block.timestamp:
     self.last_profit_update = block.timestamp
-  else:
-    self.profit_unlocking_rate = 0
 
   self._burn_shares(unlocked_shares, self)
 

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -283,7 +283,7 @@ def _total_supply() -> uint256:
   return self.total_supply - self._unlocked_shares()
 
 @internal
-def _burn_unlocked_shares() -> uint256:
+def _burn_unlocked_shares():
   """
   Burns shares that have been unlocked since last update. In case the full unlocking period has passed, it stops the unlocking
   """
@@ -298,7 +298,6 @@ def _burn_unlocked_shares() -> uint256:
     self.profit_unlocking_rate = 0
 
   self._burn_shares(unlocked_shares, self)
-  return unlocked_shares
 
 @view
 @internal

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -691,7 +691,8 @@ def _update_debt(strategy: address, target_debt: uint256) -> uint256:
         post_balance: uint256 = ASSET.balanceOf(self)
         
         # making sure we are changing according to the real result no matter what. This will spend more gas but makes it more robust
-        assets_to_withdraw = post_balance - pre_balance
+        # also prevents issues from faulty strategy that either under or over delievers 'assets_to_withdraw'
+        assets_to_withdraw = min(post_balance - pre_balance, current_debt)
 
         self.total_idle += assets_to_withdraw
         self.total_debt -= assets_to_withdraw

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -979,6 +979,7 @@ def process_report(strategy: address) -> (uint256, uint256):
 def sweep(token: address) -> (uint256):
     self._enforce_role(msg.sender, Roles.ACCOUNTING_MANAGER)
     assert token != self, "can't sweep self"
+    assert self.strategies[token].activation == 0, "can't sweep strategy"
     amount: uint256 = 0
     if token == ASSET.address:
         amount = ASSET.balanceOf(self) - self.total_idle

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -108,6 +108,7 @@ struct StrategyParams:
 MAX_BPS: constant(uint256) = 10_000
 MAX_BPS_EXTENDED: constant(uint256) = 1_000_000_000_000
 PROTOCOL_FEE_ASSESSMENT_PERIOD: constant(uint256) = 24 * 3600 # assess once a day
+API_VERSION: constant(String[28]) = "0.1.0"
 
 # ENUMS #
 enum Roles:
@@ -122,9 +123,6 @@ ASSET: immutable(ERC20)
 DECIMALS: immutable(uint256)
 PROFIT_MAX_UNLOCK_TIME: immutable(uint256)
 FACTORY: public(immutable(address))
-
-# CONSTANTS #
-API_VERSION: constant(String[28]) = "0.1.0"
 
 # STORAGE #
 # HashMap that records all the strategies that are allowed to receive assets from the vault

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -1,7 +1,6 @@
 # @version 0.3.7
 
 from vyper.interfaces import ERC20
-from vyper.interfaces import ERC4626
 from vyper.interfaces import ERC20Detailed
 
 # INTERFACES #

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -483,7 +483,7 @@ def _assess_share_of_unrealised_losses(strategy: address, assets_needed: uint256
 
 
 @internal
-def _redeem(sender: address, receiver: address, owner: address, shares_to_burn: uint256, strategies: DynArray[address, 10] = []) -> uint256:
+def _redeem(sender: address, receiver: address, owner: address, shares_to_burn: uint256, strategies: DynArray[address, 10]) -> uint256:
     if sender != owner:
         self._spend_allowance(owner, sender, shares_to_burn)
 

--- a/tests/unit/vault/test_profit_unlocking.py
+++ b/tests/unit/vault/test_profit_unlocking.py
@@ -2527,7 +2527,6 @@ def test_increase_profit_max_period__no_change(
 
     vault, strategy, _ = initial_set_up(asset, gov, amount, fish)
 
-    
     create_and_check_profit(asset, strategy, gov, vault, first_profit)
     timestamp = chain.pending_timestamp
 
@@ -2554,9 +2553,7 @@ def test_increase_profit_max_period__no_change(
         total_debt=amount + first_profit,
         total_idle=0,
         total_assets=amount + first_profit,
-        total_supply=amount
-        + first_profit
-        - first_profit // (WEEK / time_passed)
+        total_supply=amount + first_profit - first_profit // (WEEK / time_passed),
     )
 
     increase_time_and_check_profit_buffer(chain, vault, secs=WEEK // 2)
@@ -2599,7 +2596,6 @@ def test_decrease_profit_max_period__no_change(
 
     vault, strategy, _ = initial_set_up(asset, gov, amount, fish)
 
-    
     create_and_check_profit(asset, strategy, gov, vault, first_profit)
     timestamp = chain.pending_timestamp
 
@@ -2626,9 +2622,7 @@ def test_decrease_profit_max_period__no_change(
         total_debt=amount + first_profit,
         total_idle=0,
         total_assets=amount + first_profit,
-        total_supply=amount
-        + first_profit
-        - first_profit // (WEEK / time_passed)
+        total_supply=amount + first_profit - first_profit // (WEEK / time_passed),
     )
 
     increase_time_and_check_profit_buffer(chain, vault, secs=WEEK // 2)
@@ -2671,7 +2665,7 @@ def test_increase_profit_max_period__next_report_works(
     second_profit = fish_amount // 10
 
     vault, strategy, _ = initial_set_up(asset, gov, amount, fish)
-    
+
     create_and_check_profit(asset, strategy, gov, vault, first_profit)
     timestamp = chain.pending_timestamp
 
@@ -2698,9 +2692,7 @@ def test_increase_profit_max_period__next_report_works(
         total_debt=amount + first_profit,
         total_idle=0,
         total_assets=amount + first_profit,
-        total_supply=amount
-        + first_profit
-        - first_profit // (WEEK / time_passed)
+        total_supply=amount + first_profit - first_profit // (WEEK / time_passed),
     )
 
     increase_time_and_check_profit_buffer(chain, vault, secs=WEEK // 2)
@@ -2718,7 +2710,7 @@ def test_increase_profit_max_period__next_report_works(
         total_debt=amount + first_profit + second_profit,
         total_idle=0,
         total_assets=amount + first_profit + second_profit,
-        total_supply=amount + expected_new_shares, 
+        total_supply=amount + expected_new_shares,
     )
 
     # increase by a full week which is now only half the profit unlock time
@@ -2727,7 +2719,7 @@ def test_increase_profit_max_period__next_report_works(
     )
 
     time_passed = chain.pending_timestamp - timestamp
-    
+
     check_vault_totals(
         vault,
         total_debt=amount + first_profit + second_profit,
@@ -2735,7 +2727,7 @@ def test_increase_profit_max_period__next_report_works(
         total_assets=amount + first_profit + second_profit,
         total_supply=amount
         + expected_new_shares
-        - expected_new_shares // (WEEK * 2 / time_passed)
+        - expected_new_shares // (WEEK * 2 / time_passed),
     )
 
     increase_time_and_check_profit_buffer(chain, vault, secs=WEEK)
@@ -2778,7 +2770,7 @@ def test_decrease_profit_max_period__next_report_works(
     second_profit = fish_amount // 10
 
     vault, strategy, _ = initial_set_up(asset, gov, amount, fish)
-    
+
     create_and_check_profit(asset, strategy, gov, vault, first_profit)
     timestamp = chain.pending_timestamp
 
@@ -2805,9 +2797,7 @@ def test_decrease_profit_max_period__next_report_works(
         total_debt=amount + first_profit,
         total_idle=0,
         total_assets=amount + first_profit,
-        total_supply=amount
-        + first_profit
-        - first_profit // (WEEK / time_passed)
+        total_supply=amount + first_profit - first_profit // (WEEK / time_passed),
     )
 
     increase_time_and_check_profit_buffer(chain, vault, secs=WEEK // 2)
@@ -2825,7 +2815,7 @@ def test_decrease_profit_max_period__next_report_works(
         total_debt=amount + first_profit + second_profit,
         total_idle=0,
         total_assets=amount + first_profit + second_profit,
-        total_supply=amount + expected_new_shares, 
+        total_supply=amount + expected_new_shares,
     )
 
     # increase by a quarter week which is now half the profit unlock time
@@ -2834,7 +2824,7 @@ def test_decrease_profit_max_period__next_report_works(
     )
 
     time_passed = chain.pending_timestamp - timestamp
-    
+
     check_vault_totals(
         vault,
         total_debt=amount + first_profit + second_profit,
@@ -2842,7 +2832,7 @@ def test_decrease_profit_max_period__next_report_works(
         total_assets=amount + first_profit + second_profit,
         total_supply=amount
         + expected_new_shares
-        - expected_new_shares // (WEEK // 2 / time_passed)
+        - expected_new_shares // (WEEK // 2 / time_passed),
     )
 
     increase_time_and_check_profit_buffer(chain, vault, secs=WEEK // 4)

--- a/tests/unit/vault/test_profit_unlocking.py
+++ b/tests/unit/vault/test_profit_unlocking.py
@@ -2517,3 +2517,361 @@ def test_accountant_and_protcol_fees_doesnt_change_pps(
     assert vault.balanceOf(accountant.address) != 0
     assert vault.balanceOf(protocol_recipient) != 0
     assert vault.price_per_share() == starting_pps
+
+
+def test_increase_profit_max_period__no_change(
+    asset, fish_amount, fish, initial_set_up, gov, add_debt_to_strategy
+):
+    amount = fish_amount // 10
+    first_profit = fish_amount // 10
+
+    vault, strategy, _ = initial_set_up(asset, gov, amount, fish)
+
+    
+    create_and_check_profit(asset, strategy, gov, vault, first_profit)
+    timestamp = chain.pending_timestamp
+
+    assert_price_per_share(vault, 1.0)
+    check_vault_totals(
+        vault,
+        total_debt=amount + first_profit,
+        total_idle=0,
+        total_assets=amount + first_profit,
+        total_supply=amount + first_profit,
+    )
+
+    increase_time_and_check_profit_buffer(
+        chain, vault, secs=WEEK // 2, expected_buffer=first_profit // 2
+    )
+
+    # update profit max unlock time
+    vault.set_profit_max_unlock_time(WEEK * 2, sender=gov)
+
+    time_passed = chain.pending_timestamp - timestamp
+    # assure the all the amounts is what is originally would have been
+    check_vault_totals(
+        vault,
+        total_debt=amount + first_profit,
+        total_idle=0,
+        total_assets=amount + first_profit,
+        total_supply=amount
+        + first_profit
+        - first_profit // (WEEK / time_passed)
+    )
+
+    increase_time_and_check_profit_buffer(chain, vault, secs=WEEK // 2)
+
+    assert_price_per_share(vault, 2.0)
+
+    add_debt_to_strategy(gov, strategy, vault, 0)
+
+    assert vault.strategies(strategy).current_debt == 0
+    assert_price_per_share(vault, 2.0)
+    check_vault_totals(
+        vault,
+        total_debt=0,
+        total_idle=amount + first_profit,
+        total_assets=amount + first_profit,
+        total_supply=amount,
+    )
+
+    # User redeems shares
+    vault.redeem(vault.balanceOf(fish), fish, fish, [], sender=fish)
+
+    assert_price_per_share(vault, 1.0)
+    check_vault_totals(
+        vault,
+        total_debt=0,
+        total_idle=0,
+        total_assets=0,
+        total_supply=0,
+    )
+
+    assert asset.balanceOf(vault) == 0
+    assert asset.balanceOf(fish) == fish_amount + first_profit
+
+
+def test_decrease_profit_max_period__no_change(
+    asset, fish_amount, fish, initial_set_up, gov, add_debt_to_strategy
+):
+    amount = fish_amount // 10
+    first_profit = fish_amount // 10
+
+    vault, strategy, _ = initial_set_up(asset, gov, amount, fish)
+
+    
+    create_and_check_profit(asset, strategy, gov, vault, first_profit)
+    timestamp = chain.pending_timestamp
+
+    assert_price_per_share(vault, 1.0)
+    check_vault_totals(
+        vault,
+        total_debt=amount + first_profit,
+        total_idle=0,
+        total_assets=amount + first_profit,
+        total_supply=amount + first_profit,
+    )
+
+    increase_time_and_check_profit_buffer(
+        chain, vault, secs=WEEK // 2, expected_buffer=first_profit // 2
+    )
+
+    # update profit max unlock time
+    vault.set_profit_max_unlock_time(WEEK // 2, sender=gov)
+
+    time_passed = chain.pending_timestamp - timestamp
+    # assure the all the amounts is what is originally would have been
+    check_vault_totals(
+        vault,
+        total_debt=amount + first_profit,
+        total_idle=0,
+        total_assets=amount + first_profit,
+        total_supply=amount
+        + first_profit
+        - first_profit // (WEEK / time_passed)
+    )
+
+    increase_time_and_check_profit_buffer(chain, vault, secs=WEEK // 2)
+
+    assert_price_per_share(vault, 2.0)
+
+    add_debt_to_strategy(gov, strategy, vault, 0)
+
+    assert vault.strategies(strategy).current_debt == 0
+    assert_price_per_share(vault, 2.0)
+    check_vault_totals(
+        vault,
+        total_debt=0,
+        total_idle=amount + first_profit,
+        total_assets=amount + first_profit,
+        total_supply=amount,
+    )
+
+    # User redeems shares
+    vault.redeem(vault.balanceOf(fish), fish, fish, [], sender=fish)
+
+    assert_price_per_share(vault, 1.0)
+    check_vault_totals(
+        vault,
+        total_debt=0,
+        total_idle=0,
+        total_assets=0,
+        total_supply=0,
+    )
+
+    assert asset.balanceOf(vault) == 0
+    assert asset.balanceOf(fish) == fish_amount + first_profit
+
+
+def test_increase_profit_max_period__next_report_works(
+    asset, fish_amount, fish, initial_set_up, gov, add_debt_to_strategy
+):
+    amount = fish_amount // 10
+    first_profit = fish_amount // 10
+    second_profit = fish_amount // 10
+
+    vault, strategy, _ = initial_set_up(asset, gov, amount, fish)
+    
+    create_and_check_profit(asset, strategy, gov, vault, first_profit)
+    timestamp = chain.pending_timestamp
+
+    assert_price_per_share(vault, 1.0)
+    check_vault_totals(
+        vault,
+        total_debt=amount + first_profit,
+        total_idle=0,
+        total_assets=amount + first_profit,
+        total_supply=amount + first_profit,
+    )
+
+    increase_time_and_check_profit_buffer(
+        chain, vault, secs=WEEK // 2, expected_buffer=first_profit // 2
+    )
+
+    # update profit max unlock time
+    vault.set_profit_max_unlock_time(WEEK * 2, sender=gov)
+
+    time_passed = chain.pending_timestamp - timestamp
+    # assure the all the amounts is what is originally would have been
+    check_vault_totals(
+        vault,
+        total_debt=amount + first_profit,
+        total_idle=0,
+        total_assets=amount + first_profit,
+        total_supply=amount
+        + first_profit
+        - first_profit // (WEEK / time_passed)
+    )
+
+    increase_time_and_check_profit_buffer(chain, vault, secs=WEEK // 2)
+
+    assert_price_per_share(vault, 2.0)
+
+    create_and_check_profit(asset, strategy, gov, vault, second_profit)
+    timestamp = chain.pending_timestamp
+
+    assert_price_per_share(vault, 2.0)
+    # only have the amount of shares are issued due to pps = 2.0
+    expected_new_shares = second_profit // 2
+    check_vault_totals(
+        vault,
+        total_debt=amount + first_profit + second_profit,
+        total_idle=0,
+        total_assets=amount + first_profit + second_profit,
+        total_supply=amount + expected_new_shares, 
+    )
+
+    # increase by a full week which is now only half the profit unlock time
+    increase_time_and_check_profit_buffer(
+        chain, vault, secs=WEEK, expected_buffer=expected_new_shares // 2
+    )
+
+    time_passed = chain.pending_timestamp - timestamp
+    
+    check_vault_totals(
+        vault,
+        total_debt=amount + first_profit + second_profit,
+        total_idle=0,
+        total_assets=amount + first_profit + second_profit,
+        total_supply=amount
+        + expected_new_shares
+        - expected_new_shares // (WEEK * 2 / time_passed)
+    )
+
+    increase_time_and_check_profit_buffer(chain, vault, secs=WEEK)
+
+    assert_price_per_share(vault, 3.0)
+
+    add_debt_to_strategy(gov, strategy, vault, 0)
+
+    assert vault.strategies(strategy).current_debt == 0
+    assert_price_per_share(vault, 3.0)
+    check_vault_totals(
+        vault,
+        total_debt=0,
+        total_idle=amount + first_profit + second_profit,
+        total_assets=amount + first_profit + second_profit,
+        total_supply=amount,
+    )
+
+    # User redeems shares
+    vault.redeem(vault.balanceOf(fish), fish, fish, [], sender=fish)
+
+    assert_price_per_share(vault, 1.0)
+    check_vault_totals(
+        vault,
+        total_debt=0,
+        total_idle=0,
+        total_assets=0,
+        total_supply=0,
+    )
+
+    assert asset.balanceOf(vault) == 0
+    assert asset.balanceOf(fish) == fish_amount + first_profit + second_profit
+
+
+def test_decrease_profit_max_period__next_report_works(
+    asset, fish_amount, fish, initial_set_up, gov, add_debt_to_strategy
+):
+    amount = fish_amount // 10
+    first_profit = fish_amount // 10
+    second_profit = fish_amount // 10
+
+    vault, strategy, _ = initial_set_up(asset, gov, amount, fish)
+    
+    create_and_check_profit(asset, strategy, gov, vault, first_profit)
+    timestamp = chain.pending_timestamp
+
+    assert_price_per_share(vault, 1.0)
+    check_vault_totals(
+        vault,
+        total_debt=amount + first_profit,
+        total_idle=0,
+        total_assets=amount + first_profit,
+        total_supply=amount + first_profit,
+    )
+
+    increase_time_and_check_profit_buffer(
+        chain, vault, secs=WEEK // 2, expected_buffer=first_profit // 2
+    )
+
+    # update profit max unlock time
+    vault.set_profit_max_unlock_time(WEEK // 2, sender=gov)
+
+    time_passed = chain.pending_timestamp - timestamp
+    # assure the all the amounts is what is originally would have been
+    check_vault_totals(
+        vault,
+        total_debt=amount + first_profit,
+        total_idle=0,
+        total_assets=amount + first_profit,
+        total_supply=amount
+        + first_profit
+        - first_profit // (WEEK / time_passed)
+    )
+
+    increase_time_and_check_profit_buffer(chain, vault, secs=WEEK // 2)
+
+    assert_price_per_share(vault, 2.0)
+
+    create_and_check_profit(asset, strategy, gov, vault, second_profit)
+    timestamp = chain.pending_timestamp
+
+    assert_price_per_share(vault, 2.0)
+    # only have the amount of shares are issued due to pps = 2.0
+    expected_new_shares = second_profit // 2
+    check_vault_totals(
+        vault,
+        total_debt=amount + first_profit + second_profit,
+        total_idle=0,
+        total_assets=amount + first_profit + second_profit,
+        total_supply=amount + expected_new_shares, 
+    )
+
+    # increase by a quarter week which is now half the profit unlock time
+    increase_time_and_check_profit_buffer(
+        chain, vault, secs=WEEK // 4, expected_buffer=expected_new_shares // 2
+    )
+
+    time_passed = chain.pending_timestamp - timestamp
+    
+    check_vault_totals(
+        vault,
+        total_debt=amount + first_profit + second_profit,
+        total_idle=0,
+        total_assets=amount + first_profit + second_profit,
+        total_supply=amount
+        + expected_new_shares
+        - expected_new_shares // (WEEK // 2 / time_passed)
+    )
+
+    increase_time_and_check_profit_buffer(chain, vault, secs=WEEK // 4)
+
+    assert_price_per_share(vault, 3.0)
+
+    add_debt_to_strategy(gov, strategy, vault, 0)
+
+    assert vault.strategies(strategy).current_debt == 0
+    assert_price_per_share(vault, 3.0)
+    check_vault_totals(
+        vault,
+        total_debt=0,
+        total_idle=amount + first_profit + second_profit,
+        total_assets=amount + first_profit + second_profit,
+        total_supply=amount,
+    )
+
+    # User redeems shares
+    vault.redeem(vault.balanceOf(fish), fish, fish, [], sender=fish)
+
+    assert_price_per_share(vault, 1.0)
+    check_vault_totals(
+        vault,
+        total_debt=0,
+        total_idle=0,
+        total_assets=0,
+        total_supply=0,
+    )
+
+    assert asset.balanceOf(vault) == 0
+    assert asset.balanceOf(fish) == fish_amount + first_profit + second_profit

--- a/tests/unit/vault/test_role_permissioned_access.py
+++ b/tests/unit/vault/test_role_permissioned_access.py
@@ -1,5 +1,5 @@
 import ape
-from utils.constants import ROLES
+from utils.constants import ROLES, WEEK
 from utils.utils import from_units
 
 
@@ -86,6 +86,11 @@ def test_sweep__set_accounting_role_open__reverts(vault, mock_token, bunny):
         vault.sweep(mock_token, sender=bunny)
 
 
+def test_update_profit_unlock__accounting_role_closed__reverts(vault, bunny):
+    with ape.reverts():
+        vault.set_profit_max_unlock_time(WEEK * 2, sender=bunny)
+
+
 def test_process_report__set_accounting_role_open(
     vault,
     create_strategy,
@@ -118,6 +123,15 @@ def test_sweep__set_accounting_role_open(vault, fish_amount, asset, bunny, gov):
     assert len(event) == 1
     assert event[0].token == asset.address
     assert asset.balanceOf(bunny) == fish_amount
+
+
+def test_update_profit_unlock__set_accounting_role_open(vault, bunny, gov):
+    vault.set_open_role(ROLES.ACCOUNTING_MANAGER, sender=gov)
+    tx = vault.set_profit_max_unlock_time(WEEK * 2, sender=bunny)
+    event = list(tx.decode_logs(vault.UpdateProfitMaxUnlockTime))
+    assert len(event) == 1
+    assert event[0].profit_max_unlock_time == WEEK * 2
+    vault.profit_max_unlock_time() == WEEK * 2
 
 
 # DEBT_MANAGER

--- a/tests/unit/vault/test_sweep.py
+++ b/tests/unit/vault/test_sweep.py
@@ -22,7 +22,15 @@ def test_sweep__with_vault_token__reverts(gov, asset, vault):
         vault.sweep(vault.address, sender=gov)
 
 
-def test_sweep__with_strategies_token__reverts(chain, gov, asset, vault, create_strategy, mint_and_deposit_into_vault, add_debt_to_strategy):
+def test_sweep__with_strategies_token__reverts(
+    chain,
+    gov,
+    asset,
+    vault,
+    create_strategy,
+    mint_and_deposit_into_vault,
+    add_debt_to_strategy,
+):
     new_strategy = create_strategy(vault)
     vault.add_strategy(new_strategy.address, sender=gov)
 
@@ -34,7 +42,16 @@ def test_sweep__with_strategies_token__reverts(chain, gov, asset, vault, create_
         vault.sweep(new_strategy, sender=gov)
 
 
-def test_sweep__with_strategies_token__been_revoked__sweeps(chain, gov, asset, vault, create_strategy, mint_and_deposit_into_vault, add_debt_to_strategy, mint_and_deposit_into_strategy):
+def test_sweep__with_strategies_token__been_revoked__sweeps(
+    chain,
+    gov,
+    asset,
+    vault,
+    create_strategy,
+    mint_and_deposit_into_vault,
+    add_debt_to_strategy,
+    mint_and_deposit_into_strategy,
+):
     new_strategy = create_strategy(vault)
     vault.add_strategy(new_strategy.address, sender=gov)
 
@@ -44,7 +61,7 @@ def test_sweep__with_strategies_token__been_revoked__sweeps(chain, gov, asset, v
 
     with ape.reverts("can't sweep strategy"):
         vault.sweep(new_strategy, sender=gov)
-        
+
     # remove debt and revoke strategy
     vault.update_debt(new_strategy, 0, sender=gov)
     vault.revoke_strategy(new_strategy, sender=gov)

--- a/tests/unit/vault/test_sweep.py
+++ b/tests/unit/vault/test_sweep.py
@@ -22,6 +22,48 @@ def test_sweep__with_vault_token__reverts(gov, asset, vault):
         vault.sweep(vault.address, sender=gov)
 
 
+def test_sweep__with_strategies_token__reverts(chain, gov, asset, vault, create_strategy, mint_and_deposit_into_vault, add_debt_to_strategy):
+    new_strategy = create_strategy(vault)
+    vault.add_strategy(new_strategy.address, sender=gov)
+
+    mint_and_deposit_into_vault(vault)
+    vault_balance = asset.balanceOf(vault)
+    add_debt_to_strategy(gov, new_strategy, vault, vault_balance)
+
+    with ape.reverts("can't sweep strategy"):
+        vault.sweep(new_strategy, sender=gov)
+
+
+def test_sweep__with_strategies_token__been_revoked__sweeps(chain, gov, asset, vault, create_strategy, mint_and_deposit_into_vault, add_debt_to_strategy, mint_and_deposit_into_strategy):
+    new_strategy = create_strategy(vault)
+    vault.add_strategy(new_strategy.address, sender=gov)
+
+    mint_and_deposit_into_vault(vault)
+    vault_balance = asset.balanceOf(vault)
+    add_debt_to_strategy(gov, new_strategy, vault, vault_balance)
+
+    with ape.reverts("can't sweep strategy"):
+        vault.sweep(new_strategy, sender=gov)
+        
+    # remove debt and revoke strategy
+    vault.update_debt(new_strategy, 0, sender=gov)
+    vault.revoke_strategy(new_strategy, sender=gov)
+
+    # mint some strategy shares
+    mint_and_deposit_into_strategy(new_strategy, gov)
+
+    shares = new_strategy.balanceOf(gov)
+
+    # airdrop shares to the vault
+    new_strategy.transfer(vault, shares, sender=gov)
+
+    balance_before = new_strategy.balanceOf(gov)
+
+    vault.sweep(new_strategy, sender=gov)
+
+    assert new_strategy.balanceOf(gov) - balance_before == shares
+
+
 def test_sweep__with_asset_token__withdraws_airdrop_only(
     gov,
     asset,


### PR DESCRIPTION
## Remove 4626 interface
why: Its' unused

## Move api_version variable
why: Move it with the other constant variables
Should the api's be changed to use 3? i.e. 3.1.0

## Remove unused return variable from burn_unlocked_shares
why: the function is only called during the report and does not need the return variable

## Remove state update when the full unlock has passed in burn_unlocked_shares
why: This function is only ever called during a report which will update the needed profit unlock variables at the end of the report. If all shares are unlocked then they are all burned, balanceOf(self) == 0 and therefore will not effect any calculations between the burning of shares and the end of the report

## Add a min check when lowering debt 
why: Adding a min check after a withdraw will assure that we will never underflow on the subtraction from total_debt and the strategies debt even if the strategy incorrectly sends even 1 wei extra tokens when moving debt to 0.
While the 4626 standard should prevent this from happening. This will make the function more robust to potential small rounding errors, especially given vaults can deposit directly into 3rd party vaults that may not properly implement the 4626 withdraw()

## Allow accounting manager to change the profit_max_unlock_time
why: The profit_max_unlocking_time allows for yvTokens to continue to appreciate slowly between report periods. The optimal use of this is to match a reporting cycle as close as possible to the time it takes for profit to unlock. However, the optimally efficient time for a strategy to report is highly variable both across vaults and strategies but also for the same strategy depending on market conditions. For example a vault with one strategy will have different needs from multi strategy vaults, the same vault could have different needs at different times of its life based on TVL and expected returns. Justrecently Yearn has extended many vaults harvest cycles to reduce gas costs during times of lower TVL. Allowing the profit_max_unlocking_time to change means accounting managers can better match the vaults unlocking to the reporting cycles, ending in a better user experience.

## Remove default array from the internal _redeem 
why: there is already a default variable on the external redeem which is the only function that can ever call the internal one

## Check token in sweep for activation
Added protection from being able to sweep any current strategies tokens that will be minted to the vault on deposits. Will be able to sweep the strategies token if it has been force revoked previously for the potential for management to possibly recover any lost funds.

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
