### PR TITLE
fix: debt withdraw

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains the Smart Contracts for Yearns V3 vault implementation.
 
 [Vault.vy](contracts/VaultV3.vy) - The ERC4626 compliant Vault that will handle all logic associated with deposits, withdraws, strategy management, profit reporting etc.
 
+For the V3 strategy implementation see the [Tokenized Strategy](https://github.com/yearn/tokenized-strategy) repo.
+
 ## Requirements
 
 This repository runs on [ApeWorx](https://www.apeworx.io/). A python based development tool kit.

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -47,6 +47,7 @@ interface IStrategy:
     def convertToAssets(shares: uint256) -> uint256: view
     def convertToShares(assets: uint256) -> uint256: view
     def previewWithdraw(assets: uint256) -> uint256: view
+    def maxRedeem(owner: address) -> uint256: view
 
 interface IAccountant:
     def report(strategy: address, gain: uint256, loss: uint256) -> (uint256, uint256): nonpayable
@@ -653,7 +654,7 @@ def _withdraw_from_strategy(strategy: address, assets_to_withdraw: uint256):
         # Use previewWithdraw since it should round up.
         IStrategy(strategy).previewWithdraw(assets_to_withdraw), 
         # And check against our actual balance.
-        IStrategy(strategy).balanceOf(self)
+        IStrategy(strategy).maxRedeem(self)
     )
     # Redeem the shares.
     IStrategy(strategy).redeem(shares_to_redeem, self, self)

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -653,7 +653,7 @@ def _withdraw_from_strategy(strategy: address, assets_to_withdraw: uint256):
     shares_to_redeem: uint256 = min(
         # Use previewWithdraw since it should round up.
         IStrategy(strategy).previewWithdraw(assets_to_withdraw), 
-        # And check against our actual balance.
+        # And check against the max we can pull.
         IStrategy(strategy).maxRedeem(self)
     )
     # Redeem the shares.
@@ -959,8 +959,7 @@ def _update_debt(strategy: address, target_debt: uint256) -> uint256:
         post_balance: uint256 = ASSET.balanceOf(self)
         
         # making sure we are changing according to the real result no matter what. 
-        # This will spend more gas but makes it more robust. Also prevents issues
-        # from a faulty strategy that either under or over delievers 'assets_to_withdraw'
+        # We pull funds with {redeem} so there can be losses or rounding differences.
         assets_to_withdraw = min(post_balance - pre_balance, current_debt)
 
         # Update storage.

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -786,7 +786,7 @@ def _redeem(
             # Always check withdrawn against the real amounts.
             withdrawn: uint256 = post_balance - previous_balance
             loss: uint256 = 0
-            # Check if we redeemed to much.
+            # Check if we redeemed too much.
             if withdrawn > assets_to_withdraw:
                 # Make sure we don't underlfow in debt updates.
                 if withdrawn > current_debt:
@@ -832,8 +832,8 @@ def _redeem(
 
     # Check if there is a loss and a non-default value was set.
     if assets > requested_assets and max_loss < MAX_BPS:
-        # The loss is within the allowed range.
-        assert assets - requested_assets <= assets * max_loss / MAX_BPS, "to much loss"
+        # Assure the loss is within the allowed range.
+        assert assets - requested_assets <= assets * max_loss / MAX_BPS, "too much loss"
 
     # First burn the corresponding shares from the redeemer.
     self._burn_shares(shares, owner)

--- a/contracts/test/mocks/ERC4626/BaseStrategyMock.sol
+++ b/contracts/test/mocks/ERC4626/BaseStrategyMock.sol
@@ -38,7 +38,7 @@ abstract contract ERC4626BaseStrategyMock is ERC4626BaseStrategy {
         return _maxDebt > _totalAssets ? _maxDebt - _totalAssets : 0;
     }
 
-    function totalAssets() public view override returns (uint256) {
+    function totalAssets() public view virtual override returns (uint256) {
         return IERC20(asset()).balanceOf(address(this));
     }
 

--- a/contracts/test/mocks/ERC4626/FaultyStrategy.sol
+++ b/contracts/test/mocks/ERC4626/FaultyStrategy.sol
@@ -58,4 +58,22 @@ contract ERC4626FaultyStrategy is ERC4626BaseStrategyMock {
 
         return shares;
     }
+
+    function redeem(
+        uint256 _shares,
+        address _receiver,
+        address _owner
+    ) public override returns (uint256) {
+        require(
+            _shares <= maxRedeem(_owner),
+            "ERC4626: withdraw more than max"
+        );
+
+        // this will simulate withdrawing less than the vault wanted to
+        uint256 toRedeem = _shares / 2;
+        uint256 assets = previewRedeem(toRedeem);
+        _withdraw(_msgSender(), _receiver, _owner, toRedeem, assets);
+
+        return assets;
+    }
 }

--- a/contracts/test/mocks/ERC4626/LockedStrategy.sol
+++ b/contracts/test/mocks/ERC4626/LockedStrategy.sol
@@ -49,6 +49,16 @@ contract ERC4626LockedStrategy is ERC4626BaseStrategyMock {
         }
     }
 
+    function maxRedeem(address) public view override returns (uint256) {
+        uint256 balance = IERC20(asset()).balanceOf(address(this));
+        if (block.timestamp < lockedUntil) {
+            return convertToShares(balance - lockedBalance);
+        } else {
+            // no locked assets, withdraw all
+            return convertToShares(balance);
+        }
+    }
+
     function migrate(address _newStrategy) external override {
         require(lockedBalance == 0, "strat not liquid");
         IERC20(asset()).safeTransfer(

--- a/contracts/test/mocks/ERC4626/LossyStrategy.sol
+++ b/contracts/test/mocks/ERC4626/LossyStrategy.sol
@@ -8,6 +8,7 @@ contract ERC4626LossyStrategy is ERC4626BaseStrategyMock {
     using SafeERC20 for IERC20;
 
     uint256 public withdrawingLoss;
+    uint256 public lockedFunds;
 
     constructor(
         address _vault,
@@ -21,6 +22,10 @@ contract ERC4626LossyStrategy is ERC4626BaseStrategyMock {
 
     function setWithdrawingLoss(uint256 _loss) external {
         withdrawingLoss = _loss;
+    }
+
+    function setLockedFunds(uint256 _lockedFunds) external {
+        lockedFunds = _lockedFunds;
     }
 
     function _withdraw(
@@ -54,7 +59,7 @@ contract ERC4626LossyStrategy is ERC4626BaseStrategyMock {
     ) internal override returns (uint256 _amountFreed) {}
 
     function maxWithdraw(address) public view override returns (uint256) {
-        return IERC20(asset()).balanceOf(address(this));
+        return IERC20(asset()).balanceOf(address(this)) - lockedFunds;
     }
 
     function migrate(address _newStrategy) external override {

--- a/contracts/test/mocks/ERC4626/LossyStrategy.sol
+++ b/contracts/test/mocks/ERC4626/LossyStrategy.sol
@@ -7,7 +7,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 contract ERC4626LossyStrategy is ERC4626BaseStrategyMock {
     using SafeERC20 for IERC20;
 
-    uint256 public withdrawingLoss;
+    int256 public withdrawingLoss;
     uint256 public lockedFunds;
 
     constructor(
@@ -20,12 +20,20 @@ contract ERC4626LossyStrategy is ERC4626BaseStrategyMock {
         IERC20(asset()).safeTransfer(_target, _loss);
     }
 
-    function setWithdrawingLoss(uint256 _loss) external {
+    function setWithdrawingLoss(int256 _loss) external {
         withdrawingLoss = _loss;
     }
 
     function setLockedFunds(uint256 _lockedFunds) external {
         lockedFunds = _lockedFunds;
+    }
+
+    function totalAssets() public view override returns (uint256) {
+        if (withdrawingLoss < 0) {
+            return uint256(int256(IERC20(asset()).balanceOf(address(this))) + withdrawingLoss);
+        } else {
+            return super.totalAssets();
+        }
     }
 
     function _withdraw(
@@ -39,17 +47,20 @@ contract ERC4626LossyStrategy is ERC4626BaseStrategyMock {
             _spendAllowance(_owner, _caller, _shares);
         }
 
+        uint256 toWithdraw = uint256(int256(_assets) - withdrawingLoss);
         _burn(_owner, _shares);
         // Withdrawing loss simulates a loss while withdrawing
-        IERC20(asset()).safeTransfer(_receiver, _assets - withdrawingLoss);
-        // burns (to simulate loss while withdrawing)
-        IERC20(asset()).safeTransfer(asset(), withdrawingLoss);
+        IERC20(asset()).safeTransfer(_receiver, toWithdraw);
+        if(withdrawingLoss > 0) {
+            // burns (to simulate loss while withdrawing)
+            IERC20(asset()).safeTransfer(asset(), uint256(withdrawingLoss));
+        }
 
         emit Withdraw(
             _caller,
             _receiver,
             _owner,
-            _assets - withdrawingLoss,
+            toWithdraw,
             _shares
         );
     }

--- a/tests/unit/vault/test_strategy_withdraw.py
+++ b/tests/unit/vault/test_strategy_withdraw.py
@@ -330,7 +330,7 @@ def test_withdraw__with_lossy_strategy__no_max_loss__reverts(
     # lose half of assets in lossy strategy
     lossy_strategy.setLoss(gov, amount_to_lose, sender=gov)
 
-    with ape.reverts("to much loss"):
+    with ape.reverts("too much loss"):
         vault.withdraw(
             amount_to_withdraw,
             fish.address,
@@ -964,7 +964,7 @@ def test_withdraw__with_liquid_and_lossy_strategy_that_losses_while_withdrawing_
     # lose half of assets in lossy strategy
     lossy_strategy.setWithdrawingLoss(amount_to_lose, sender=gov)
 
-    with ape.reverts("to much loss"):
+    with ape.reverts("too much loss"):
         tx = vault.withdraw(
             amount_to_withdraw,
             fish.address,
@@ -1167,7 +1167,7 @@ def test_redeem__half_of_assets_from_lossy_strategy_that_losses_while_withdrawin
     # lose half of assets in lossy strategy
     lossy_strategy.setWithdrawingLoss(amount_to_lose, sender=gov)
 
-    with ape.reverts("to much loss"):
+    with ape.reverts("too much loss"):
         vault.redeem(
             amount_to_withdraw,
             fish.address,
@@ -1219,7 +1219,7 @@ def test_withdraw__half_of_strategy_assets_from_lossy_strategy_with_unrealised_l
     # lose half of assets in lossy strategy
     lossy_strategy.setLoss(gov, amount_to_lose, sender=gov)
 
-    with ape.reverts("to much loss"):
+    with ape.reverts("too much loss"):
         tx = vault.withdraw(
             amount_to_withdraw,
             fish.address,
@@ -1454,7 +1454,7 @@ def test_redeem__half_of_strategy_assets_from_locked_lossy_strategy_with_unreali
     # Lock half the remaining funds.
     lossy_strategy.setLockedFunds(amount_to_lock, DAY, sender=gov)
 
-    with ape.reverts("to much loss"):
+    with ape.reverts("too much loss"):
         vault.redeem(
             amount_to_withdraw,
             fish.address,

--- a/tests/unit/vault/test_strategy_withdraw.py
+++ b/tests/unit/vault/test_strategy_withdraw.py
@@ -1178,6 +1178,476 @@ def test_redeem__half_of_assets_from_lossy_strategy_that_losses_while_withdrawin
         )
 
 
+def test_withdraw__from_lossy_strategy_with_unrealised_losses(
+    gov,
+    fish,
+    fish_amount,
+    asset,
+    create_vault,
+    create_strategy,
+    create_lossy_strategy,
+    user_deposit,
+    add_strategy_to_vault,
+    add_debt_to_strategy,
+):
+    vault = create_vault(asset)
+    amount = fish_amount
+    amount_per_strategy = amount  # deposit all of amount to strategy
+    amount_to_lose = amount_per_strategy // 2  # loss only half of strategy
+    amount_to_withdraw = amount
+    shares = amount
+    lossy_strategy = create_lossy_strategy(vault)
+    strategies = [lossy_strategy]
+    max_loss = 10_000
+
+    # deposit assets to vault
+    user_deposit(fish, vault, asset, amount)
+
+    # set up strategies
+    vault.set_role(
+        gov.address,
+        ROLES.ADD_STRATEGY_MANAGER | ROLES.DEBT_MANAGER | ROLES.MAX_DEBT_MANAGER,
+        sender=gov,
+    )
+
+    add_strategy_to_vault(gov, lossy_strategy, vault)
+    add_debt_to_strategy(gov, lossy_strategy, vault, amount_per_strategy)
+
+    # lose half of assets in lossy strategy
+    lossy_strategy.setLoss(gov, amount_to_lose, sender=gov)
+
+    tx = vault.withdraw(
+        amount_to_withdraw,
+        fish.address,
+        fish.address,
+        max_loss,
+        [s.address for s in strategies],
+        sender=fish,
+    )
+
+    event = list(tx.decode_logs(vault.Withdraw))
+
+    assert len(event) >= 1
+    n = len(event) - 1
+    assert event[n].sender == fish
+    assert event[n].receiver == fish
+    assert event[n].owner == fish
+    assert event[n].shares == shares
+    assert event[n].assets == amount_to_withdraw - amount_to_lose
+
+    event = list(tx.decode_logs(vault.DebtUpdated))
+
+    assert len(event) == 1
+    assert event[0].strategy == lossy_strategy.address
+    assert event[0].current_debt == amount_per_strategy
+    assert event[0].new_debt == 0
+
+    assert vault.totalAssets() == 0
+    assert vault.totalSupply() == 0
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == 0
+    assert asset.balanceOf(vault) == 0
+    assert asset.balanceOf(lossy_strategy) == 0
+    assert lossy_strategy.totalAssets() == 0
+    assert asset.balanceOf(fish) == amount_to_withdraw - amount_to_lose
+    assert vault.balanceOf(fish) == 0
+
+
+def test_redeem__from_lossy_strategy_with_unrealised_losses(
+    gov,
+    fish,
+    fish_amount,
+    asset,
+    create_vault,
+    create_strategy,
+    create_lossy_strategy,
+    user_deposit,
+    add_strategy_to_vault,
+    add_debt_to_strategy,
+):
+    vault = create_vault(asset)
+    amount = fish_amount
+    amount_per_strategy = amount  # deposit all of amount to strategy
+    amount_to_lose = amount_per_strategy // 2  # loss only half of strategy
+    shares = amount
+    amount_to_redeem = shares
+    lossy_strategy = create_lossy_strategy(vault)
+    strategies = [lossy_strategy]
+    max_loss = 10_000
+
+    # deposit assets to vault
+    user_deposit(fish, vault, asset, amount)
+
+    # set up strategies
+    vault.set_role(
+        gov.address,
+        ROLES.ADD_STRATEGY_MANAGER | ROLES.DEBT_MANAGER | ROLES.MAX_DEBT_MANAGER,
+        sender=gov,
+    )
+
+    add_strategy_to_vault(gov, lossy_strategy, vault)
+    add_debt_to_strategy(gov, lossy_strategy, vault, amount_per_strategy)
+
+    # lose half of assets in lossy strategy
+    lossy_strategy.setLoss(gov, amount_to_lose, sender=gov)
+
+    tx = vault.redeem(
+        amount_to_redeem,
+        fish.address,
+        fish.address,
+        max_loss,
+        [s.address for s in strategies],
+        sender=fish,
+    )
+
+    event = list(tx.decode_logs(vault.Withdraw))
+
+    assert len(event) >= 1
+    n = len(event) - 1
+    assert event[n].sender == fish
+    assert event[n].receiver == fish
+    assert event[n].owner == fish
+    assert event[n].shares == amount_to_redeem
+    assert event[n].assets == amount - amount_to_lose
+
+    event = list(tx.decode_logs(vault.DebtUpdated))
+
+    assert len(event) == 1
+    assert event[0].strategy == lossy_strategy.address
+    assert event[0].current_debt == amount_per_strategy
+    assert event[0].new_debt == 0
+
+    assert vault.totalAssets() == 0
+    assert vault.totalSupply() == 0
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == 0
+    assert asset.balanceOf(vault) == 0
+    assert asset.balanceOf(lossy_strategy) == 0
+    assert lossy_strategy.totalAssets() == 0
+    assert asset.balanceOf(fish) == amount - amount_to_lose
+    assert vault.balanceOf(fish) == 0
+
+
+def test_withdraw__from_lossy_strategy_with_unrealised_losses_and_max_deposit(
+    gov,
+    fish,
+    fish_amount,
+    asset,
+    create_vault,
+    create_strategy,
+    create_lossy_strategy,
+    user_deposit,
+    add_strategy_to_vault,
+    add_debt_to_strategy,
+):
+    vault = create_vault(asset)
+    amount = fish_amount
+    amount_per_strategy = amount // 2  # deposit all of amount to strategy
+    amount_to_lose = amount_per_strategy // 4  # loss only half of strategy
+    amount_to_lock = (amount_per_strategy - amount_to_lose) // 2
+    amount_to_withdraw = amount * 3 // 4
+    shares = amount_to_withdraw
+    lossy_strategy = create_lossy_strategy(vault)
+    liquid_strategy = create_strategy(vault)
+    strategies = [lossy_strategy, liquid_strategy]
+    max_loss = 10_000
+
+    # deposit assets to vault
+    user_deposit(fish, vault, asset, amount)
+
+    # set up strategies
+    vault.set_role(
+        gov.address,
+        ROLES.ADD_STRATEGY_MANAGER | ROLES.DEBT_MANAGER | ROLES.MAX_DEBT_MANAGER,
+        sender=gov,
+    )
+
+    for strategy in strategies:
+        add_strategy_to_vault(gov, strategy, vault)
+        add_debt_to_strategy(gov, strategy, vault, amount_per_strategy)
+
+    # lose half of assets in lossy strategy
+    lossy_strategy.setLoss(gov, amount_to_lose, sender=gov)
+    lossy_strategy.setLockedFunds(amount_to_lock, sender=gov)
+
+    tx = vault.withdraw(
+        amount_to_withdraw,
+        fish.address,
+        fish.address,
+        max_loss,
+        [s.address for s in strategies],
+        sender=fish,
+    )
+
+    event = list(tx.decode_logs(vault.Withdraw))
+
+    assert len(event) >= 1
+    n = len(event) - 1
+    assert event[n].sender == fish
+    assert event[n].receiver == fish
+    assert event[n].owner == fish
+    assert event[n].shares == shares
+    assert event[n].assets == amount_to_withdraw - (amount_to_lose // 2)
+
+    event = list(tx.decode_logs(vault.DebtUpdated))
+
+    assert len(event) == 2
+    assert event[0].strategy == lossy_strategy.address
+    assert event[0].current_debt == amount_per_strategy
+    assert event[0].new_debt == amount_to_lock + (amount_to_lose // 2)
+
+    assert event[1].strategy == strategy.address
+    assert event[1].current_debt == amount_per_strategy
+    assert event[1].new_debt == 0
+
+    assert vault.totalAssets() == amount - amount_to_withdraw
+    assert vault.totalSupply() == amount - amount_to_withdraw
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == amount - amount_to_withdraw
+    assert asset.balanceOf(vault) == 0
+    assert asset.balanceOf(lossy_strategy) == amount_to_lock
+    assert lossy_strategy.totalAssets() == amount_to_lock
+    assert asset.balanceOf(strategy) == 0
+    assert liquid_strategy.totalAssets() == 0
+    assert asset.balanceOf(fish) == amount_to_withdraw - (amount_to_lose // 2)
+    assert vault.balanceOf(fish) == amount - amount_to_withdraw
+
+
+def test_redeem__from_lossy_strategy_with_unrealised_losses_and_max_deposit(
+    gov,
+    fish,
+    fish_amount,
+    asset,
+    create_vault,
+    create_strategy,
+    create_lossy_strategy,
+    user_deposit,
+    add_strategy_to_vault,
+    add_debt_to_strategy,
+):
+    vault = create_vault(asset)
+    amount = fish_amount
+    amount_per_strategy = amount // 2  # deposit all of amount to strategy
+    amount_to_lose = amount_per_strategy // 4  # loss only half of strategy
+    amount_to_lock = (amount_per_strategy - amount_to_lose) // 2
+    amount_to_withdraw = amount * 3 // 4
+    shares = amount_to_withdraw
+    lossy_strategy = create_lossy_strategy(vault)
+    liquid_strategy = create_strategy(vault)
+    strategies = [lossy_strategy, liquid_strategy]
+    max_loss = 10_000
+
+    # deposit assets to vault
+    user_deposit(fish, vault, asset, amount)
+
+    # set up strategies
+    vault.set_role(
+        gov.address,
+        ROLES.ADD_STRATEGY_MANAGER | ROLES.DEBT_MANAGER | ROLES.MAX_DEBT_MANAGER,
+        sender=gov,
+    )
+
+    for strategy in strategies:
+        add_strategy_to_vault(gov, strategy, vault)
+        add_debt_to_strategy(gov, strategy, vault, amount_per_strategy)
+
+    # lose half of assets in lossy strategy
+    lossy_strategy.setLoss(gov, amount_to_lose, sender=gov)
+    lossy_strategy.setLockedFunds(amount_to_lock, sender=gov)
+
+    tx = vault.withdraw(
+        shares,
+        fish.address,
+        fish.address,
+        max_loss,
+        [s.address for s in strategies],
+        sender=fish,
+    )
+
+    event = list(tx.decode_logs(vault.Withdraw))
+
+    assert len(event) >= 1
+    n = len(event) - 1
+    assert event[n].sender == fish
+    assert event[n].receiver == fish
+    assert event[n].owner == fish
+    assert event[n].shares == shares
+    assert event[n].assets == amount_to_withdraw - (amount_to_lose // 2)
+
+    event = list(tx.decode_logs(vault.DebtUpdated))
+
+    assert len(event) == 2
+    assert event[0].strategy == lossy_strategy.address
+    assert event[0].current_debt == amount_per_strategy
+    assert event[0].new_debt == amount_to_lock + (amount_to_lose // 2)
+
+    assert event[1].strategy == strategy.address
+    assert event[1].current_debt == amount_per_strategy
+    assert event[1].new_debt == 0
+
+    assert vault.totalAssets() == amount - amount_to_withdraw
+    assert vault.totalSupply() == amount - amount_to_withdraw
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == amount - amount_to_withdraw
+    assert asset.balanceOf(vault) == 0
+    assert asset.balanceOf(lossy_strategy) == amount_to_lock
+    assert lossy_strategy.totalAssets() == amount_to_lock
+    assert asset.balanceOf(strategy) == 0
+    assert liquid_strategy.totalAssets() == 0
+    assert asset.balanceOf(fish) == amount_to_withdraw - (amount_to_lose // 2)
+    assert vault.balanceOf(fish) == amount - amount_to_withdraw
+
+
+def test_withdraw__from_lossy_strategy_with_unrealised_losses_full_strategy(
+    gov,
+    fish,
+    fish_amount,
+    asset,
+    create_vault,
+    create_strategy,
+    create_lossy_strategy,
+    user_deposit,
+    add_strategy_to_vault,
+    add_debt_to_strategy,
+):
+    vault = create_vault(asset)
+    amount = fish_amount
+    amount_per_strategy = amount  # deposit all of amount to strategy
+    amount_to_lose = amount_per_strategy  # loss all of the strategy
+    amount_to_withdraw = amount
+    shares = amount
+    lossy_strategy = create_lossy_strategy(vault)
+    strategies = [lossy_strategy]
+    max_loss = 10_000
+
+    # deposit assets to vault
+    user_deposit(fish, vault, asset, amount)
+
+    # set up strategies
+    vault.set_role(
+        gov.address,
+        ROLES.ADD_STRATEGY_MANAGER | ROLES.DEBT_MANAGER | ROLES.MAX_DEBT_MANAGER,
+        sender=gov,
+    )
+
+    add_strategy_to_vault(gov, lossy_strategy, vault)
+    add_debt_to_strategy(gov, lossy_strategy, vault, amount_per_strategy)
+
+    # lose half of assets in lossy strategy
+    lossy_strategy.setLoss(gov, amount_to_lose, sender=gov)
+
+    tx = vault.withdraw(
+        amount_to_withdraw,
+        fish.address,
+        fish.address,
+        max_loss,
+        [s.address for s in strategies],
+        sender=fish,
+    )
+
+    event = list(tx.decode_logs(vault.Withdraw))
+
+    assert len(event) >= 1
+    n = len(event) - 1
+    assert event[n].sender == fish
+    assert event[n].receiver == fish
+    assert event[n].owner == fish
+    assert event[n].shares == shares
+    assert event[n].assets == 0
+
+    event = list(tx.decode_logs(vault.DebtUpdated))
+
+    assert len(event) == 1
+    assert event[0].strategy == lossy_strategy.address
+    assert event[0].current_debt == amount_per_strategy
+    assert event[0].new_debt == 0
+
+    assert vault.totalAssets() == 0
+    assert vault.totalSupply() == 0
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == 0
+    assert asset.balanceOf(vault) == 0
+    assert asset.balanceOf(lossy_strategy) == 0
+    assert lossy_strategy.totalAssets() == 0
+    assert asset.balanceOf(fish) == 0
+    assert vault.balanceOf(fish) == 0
+
+
+def test_redeem__from_lossy_strategy_with_unrealised_losses_all_of_strategy(
+    gov,
+    fish,
+    fish_amount,
+    asset,
+    create_vault,
+    create_strategy,
+    create_lossy_strategy,
+    user_deposit,
+    add_strategy_to_vault,
+    add_debt_to_strategy,
+):
+    vault = create_vault(asset)
+    amount = fish_amount
+    amount_per_strategy = amount  # deposit all of amount to strategy
+    amount_to_lose = amount_per_strategy  # loss all of the funds
+    shares = amount
+    amount_to_redeem = shares
+    lossy_strategy = create_lossy_strategy(vault)
+    strategies = [lossy_strategy]
+    max_loss = 10_000
+
+    # deposit assets to vault
+    user_deposit(fish, vault, asset, amount)
+
+    # set up strategies
+    vault.set_role(
+        gov.address,
+        ROLES.ADD_STRATEGY_MANAGER | ROLES.DEBT_MANAGER | ROLES.MAX_DEBT_MANAGER,
+        sender=gov,
+    )
+
+    add_strategy_to_vault(gov, lossy_strategy, vault)
+    add_debt_to_strategy(gov, lossy_strategy, vault, amount_per_strategy)
+
+    # lose half of assets in lossy strategy
+    lossy_strategy.setLoss(gov, amount_to_lose, sender=gov)
+
+    tx = vault.redeem(
+        amount_to_redeem,
+        fish.address,
+        fish.address,
+        max_loss,
+        [s.address for s in strategies],
+        sender=fish,
+    )
+
+    event = list(tx.decode_logs(vault.Withdraw))
+
+    assert len(event) >= 1
+    n = len(event) - 1
+    assert event[n].sender == fish
+    assert event[n].receiver == fish
+    assert event[n].owner == fish
+    assert event[n].shares == amount_to_redeem
+    assert event[n].assets == 0
+
+    event = list(tx.decode_logs(vault.DebtUpdated))
+
+    assert len(event) == 1
+    assert event[0].strategy == lossy_strategy.address
+    assert event[0].current_debt == amount_per_strategy
+    assert event[0].new_debt == 0
+
+    assert vault.totalAssets() == 0
+    assert vault.totalSupply() == 0
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == 0
+    assert asset.balanceOf(vault) == 0
+    assert asset.balanceOf(lossy_strategy) == 0
+    assert lossy_strategy.totalAssets() == 0
+    assert asset.balanceOf(fish) == amount - amount_to_lose
+    assert vault.balanceOf(fish) == 0
+
+
 def test_withdraw__half_of_strategy_assets_from_lossy_strategy_with_unrealised_losses__no_max_fee__reverts(
     gov,
     fish,


### PR DESCRIPTION
## Description

Use redeem instead of withdraw on debt updates so we can natively take on losses.

Fixes # (issue)
#174 
## Checklist

- [ ] I have run vyper and solidity linting
- [ ] I have run the tests on my machine
- [ ] I have followed commitlint guidelines
- [ ] I have rebased my changes to the latest version of the main branch
