### PR TITLE
feat: add debt max loss

### DIFF
--- a/TECH_SPEC.md
+++ b/TECH_SPEC.md
@@ -163,7 +163,7 @@ This responsibility is taken by callers with DEBT_MANAGER role
 
 This role can increase or decrease strategies specific debt.
 
-The vault sends and receives funds to/from strategies. The function updateDebt(strategy, target_debt) will set the current_debt of the strategy to target_debt (if possible)
+The vault sends and receives funds to/from strategies. The function update_debt(strategy, target_debt, max_loss) will set the current_debt of the strategy to target_debt (if possible)
 
 If the strategy currently has less debt than the target_debt, the vault will send funds to it.
 


### PR DESCRIPTION
## Description

- Add an optional parameter to debt updates of 'max_loss' that works just like the redeem function.
- defaults to 100%

Fixes # (issue)

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
