### PR TITLE
build: only burn or mint

### DIFF
--- a/contracts/test/mocks/ERC4626/MockTokenizedStrategy.sol
+++ b/contracts/test/mocks/ERC4626/MockTokenizedStrategy.sol
@@ -58,7 +58,7 @@ contract MockTokenizedStrategy is TokenizedStrategy {
     function availableDepositLimit(
         address
     ) public view virtual returns (uint256) {
-        uint256 _totalAssets = strategyStorage().totalIdle;
+        uint256 _totalAssets = totalAssets();
         uint256 _maxDebt = maxDebt;
         return _maxDebt > _totalAssets ? _maxDebt - _totalAssets : 0;
     }


### PR DESCRIPTION
## Description

Most reports will burn shares twice and mint once causing unnecesary gas usage.

This will calculate the end state of shares first and then only burn OR mint depending on the amount needed to change.

Fixes # (issue)

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
