### PR TITLE
feat: minor fixes

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -9,7 +9,7 @@ default_ecosystem: ethereum
 dependencies:
   - name: openzeppelin
     github: OpenZeppelin/openzeppelin-contracts
-    ref: 4.7.3
+    ref: 4.9.5
   - name: tokenized-strategy
     github: yearn/tokenized-strategy
     ref: dev_302
@@ -17,7 +17,7 @@ dependencies:
 
 solidity:
   import_remapping:
-    - "@openzeppelin/contracts=openzeppelin/v4.7.3"
+    - "@openzeppelin/contracts=openzeppelin/v4.9.5"
     - "@tokenized-strategy=tokenized-strategy/dev_302"
 
 ethereum:

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -2013,7 +2013,7 @@ def maxRedeem(
     """
     return min(
         # Convert to shares is rounding up so we check against the full balance.
-        self._convert_to_shares(self._max_withdraw(owner, max_loss, strategies), Rounding.ROUND_UP),
+        self._convert_to_shares(self._max_withdraw(owner, max_loss, strategies), Rounding.ROUND_DOWN),
         self.balance_of[owner]
     )
 

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -2012,7 +2012,7 @@ def maxRedeem(
     @return The maximum amount of shares that can be redeemed.
     """
     return min(
-        # Convert to shares is rounding up so we check against the full balance.
+        # Min of the shares equivalent of max_withdraw or the full balance
         self._convert_to_shares(self._max_withdraw(owner, max_loss, strategies), Rounding.ROUND_DOWN),
         self.balance_of[owner]
     )

--- a/contracts/test/ERC4626BaseStrategy.sol
+++ b/contracts/test/ERC4626BaseStrategy.sol
@@ -20,7 +20,7 @@ abstract contract ERC4626BaseStrategy is ERC4626 {
     constructor(
         address _vault,
         address _asset
-    ) ERC4626(IERC20Metadata(address(_asset))) {
+    ) ERC4626(IERC20(address(_asset))) {
         _initialize(_vault, _asset);
     }
 
@@ -30,13 +30,7 @@ abstract contract ERC4626BaseStrategy is ERC4626 {
         vault = _vault;
     }
 
-    function decimals()
-        public
-        view
-        virtual
-        override(ERC20, IERC20Metadata)
-        returns (uint8)
-    {
+    function decimals() public view virtual override returns (uint8) {
         return _decimals;
     }
 

--- a/contracts/test/mocks/ERC4626/MockTokenizedStrategy.sol
+++ b/contracts/test/mocks/ERC4626/MockTokenizedStrategy.sol
@@ -42,6 +42,7 @@ contract MockTokenizedStrategy is TokenizedStrategy {
         maxDebt = _maxDebt;
     }
 
+
     function availableDepositLimit(
         address
     ) public view virtual returns (uint256) {

--- a/contracts/test/mocks/ERC4626/MockTokenizedStrategy.sol
+++ b/contracts/test/mocks/ERC4626/MockTokenizedStrategy.sol
@@ -42,7 +42,6 @@ contract MockTokenizedStrategy is TokenizedStrategy {
         maxDebt = _maxDebt;
     }
 
-
     function availableDepositLimit(
         address
     ) public view virtual returns (uint256) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "yearn-vaults-v3",
     "devDependencies": {
-        "@openzeppelin/contracts": "^4.7.3",
+        "@openzeppelin/contracts": "^4.9.0",
         "hardhat": "^2.12.2",
         "prettier": "^2.6.0",
         "prettier-plugin-solidity": "^1.0.0-beta.19",


### PR DESCRIPTION
## Description

- Check for 0 assets
- Don't cache unnecessary variables in redeem
- dont burn shares if there are none
- clarify variable name in unrealized loss assesment
- bump oz version up 
- Use convertToShares instead of previewWithdraw in maxRedeem.
This will round down instead of up. Eliminating a potential issue caused by double rounding in which the convertToAssets in redeem will return a value slightly higher than the max_withdraw


## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
