### PR TITLE
feat: add to queue flag

### DIFF
--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -969,7 +969,7 @@ def _redeem(
 
 ## STRATEGY MANAGEMENT ##
 @internal
-def _add_strategy(new_strategy: address):
+def _add_strategy(new_strategy: address, add_to_queue: bool):
     assert new_strategy not in [self, empty(address)], "strategy cannot be zero address"
     assert IStrategy(new_strategy).asset() == self.asset, "invalid asset"
     assert self.strategies[new_strategy].activation == 0, "strategy already active"
@@ -982,8 +982,8 @@ def _add_strategy(new_strategy: address):
         max_debt: 0
     })
 
-    # If the default queue has space, add the strategy.
-    if len(self.default_queue) < MAX_QUEUE:
+    # If we are adding to the queue and the default queue has space, add the strategy.
+    if add_to_queue and len(self.default_queue) < MAX_QUEUE:
         self.default_queue.append(new_strategy)        
         
     log StrategyChanged(new_strategy, StrategyChangeType.ADDED)
@@ -1645,13 +1645,13 @@ def buy_debt(strategy: address, amount: uint256):
 
 ## STRATEGY MANAGEMENT ##
 @external
-def add_strategy(new_strategy: address):
+def add_strategy(new_strategy: address, add_to_queue: bool=True):
     """
     @notice Add a new strategy.
     @param new_strategy The new strategy to add.
     """
     self._enforce_role(msg.sender, Roles.ADD_STRATEGY_MANAGER)
-    self._add_strategy(new_strategy)
+    self._add_strategy(new_strategy, add_to_queue)
 
 @external
 def revoke_strategy(strategy: address):

--- a/tests/unit/vault/test_queue_management.py
+++ b/tests/unit/vault/test_queue_management.py
@@ -230,7 +230,6 @@ def test_withdraw__queue__with_inactive_strategy__reverts(
         )
 
 
-# TODO: Add test to check removal and adding strategies works.
 def test__add_strategy__adds_to_queue(create_vault, asset, gov, create_strategy):
     vault = create_vault(asset)
 
@@ -245,6 +244,23 @@ def test__add_strategy__adds_to_queue(create_vault, asset, gov, create_strategy)
     vault.add_strategy(strategy_two.address, sender=gov)
 
     assert vault.get_default_queue() == [strategy_one.address, strategy_two.address]
+
+
+def test__add_strategy__dont_add_to_queue(create_vault, asset, gov, create_strategy):
+    vault = create_vault(asset)
+
+    assert vault.get_default_queue() == []
+
+    strategy_one = create_strategy(vault)
+    vault.add_strategy(strategy_one.address, False, sender=gov)
+
+    assert vault.get_default_queue() == []
+    assert vault.strategies(strategy_one)["activation"] != 0
+
+    strategy_two = create_strategy(vault)
+    vault.add_strategy(strategy_two.address, False, sender=gov)
+
+    assert vault.get_default_queue() == []
 
 
 def test__add_eleven_strategies__adds_ten_to_queue(
@@ -292,6 +308,23 @@ def test__revoke_strategy__removes_strategy_from_queue(
     vault.revoke_strategy(strategy_one.address, sender=gov)
 
     assert vault.strategies(strategy_one.address)["activation"] == 0
+    assert vault.get_default_queue() == []
+
+
+def test__revoke_strategy_not_in_queue(create_vault, asset, gov, create_strategy):
+    vault = create_vault(asset)
+
+    assert vault.get_default_queue() == []
+
+    strategy_one = create_strategy(vault)
+    vault.add_strategy(strategy_one.address, False, sender=gov)
+
+    assert vault.get_default_queue() == []
+    assert vault.strategies(strategy_one)["activation"] != 0
+
+    vault.revoke_strategy(strategy_one.address, sender=gov)
+
+    assert vault.strategies(strategy_one)["activation"] == 0
     assert vault.get_default_queue() == []
 
 


### PR DESCRIPTION
## Description

Add an optiona `add_to_queue` flag on the add_strategy function that can allow the strategy to not automatically be added to the default_queue when added to the vualt.

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
