### PR TITLE
build: auto allocate

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: 3.9
 
       - name: Set pip cache directory path
         id: pip-cache-dir-path

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
 
       - name: Set pip cache directory path
         id: pip-cache-dir-path

--- a/TECH_SPEC.md
+++ b/TECH_SPEC.md
@@ -173,6 +173,13 @@ The vault checks that the `minimumTotalIdle` parameter is respected (i.e. there'
 
 If the strategy has more debt than the max_debt, the vault will request the funds back. These funds may be locked in the strategy, which will result in the strategy returning less funds than requested by the vault. 
 
+#### Auto Allocations
+The DEBT_MANAGER can set the vaults `auto_allocate` flag to `True`.
+
+This will cause every deposit or mint call to end by the vault pushing as much debt as possible to the first strategy in the queue.
+
+NOTE: Not having at least 1 strategy in the `default_queue` with the `auto_allocate` flag will cause all deposits to revert.
+
 #### Setting maximum debt for a specific strategy
 The MAX_DEBT_MANAGER can set the maximum amount of tokens the vault will allow a strategy to owe at any moment in time.
 

--- a/TECH_SPEC.md
+++ b/TECH_SPEC.md
@@ -129,11 +129,7 @@ Every role can be filled by an EOA, multi-sig or other smart contracts. Each rol
 
 The account that manages roles is a single account, set in `role_manager`.
 
-This role_manager can be an EOA, a multi-sig or a Governance Module that relays calls. 
-
-The vault comes with the ability to "open" every role. Meaning that any function that requires the caller to hold that role would be come permsissionless.
-
-The vault imposes no restrictions on the role managers ability to open or close any role. **But this should be done with extreme care as most of the roles are not meant to be opened and can lead to loss of funds if done incorrectly**.
+This role_manager can be an EOA, a multi-sig or a Governance contract that relays calls. 
 
 ### Strategy Management
 This responsibility is taken by callers with ADD_STRATEGY_MANAGER, REVOKE_STRATEGY_MANAGER and FORCE_REVOKE_MANAGER roles

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -687,7 +687,7 @@ def _deposit(sender: address, recipient: address, assets: uint256) -> uint256:
 
     assert shares > 0, "cannot mint zero"
 
-    log Deposit(sender, recipient, assets, shares)
+    log Deposit(sender, recipient, amount, shares)
 
     if self.auto_allocate:
         self._update_debt(self.default_queue[0], max_value(uint256), 0)

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -1066,11 +1066,13 @@ def _update_debt(strategy: address, target_debt: uint256, max_loss: uint256) -> 
         withdrawable: uint256 = IStrategy(strategy).convertToAssets(
             IStrategy(strategy).maxRedeem(self)
         )
-        assert withdrawable != 0, "nothing to withdraw"
 
         # If insufficient withdrawable, withdraw what we can.
         if withdrawable < assets_to_withdraw:
             assets_to_withdraw = withdrawable
+
+        if assets_to_withdraw == 0:
+            return current_debt
 
         # If there are unrealised losses we don't let the vault reduce its debt until there is a new report
         unrealised_losses_share: uint256 = self._assess_share_of_unrealised_losses(strategy, current_debt, assets_to_withdraw)
@@ -1106,7 +1108,7 @@ def _update_debt(strategy: address, target_debt: uint256, max_loss: uint256) -> 
     else: 
         # We are increasing the strategies debt
 
-        # Respect the maximum amount allowed. TODO: Should this just check if max uint?
+        # Respect the maximum amount allowed.
         max_debt: uint256 = self.strategies[strategy].max_debt
         if new_debt > max_debt:
             new_debt = max_debt

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -1804,6 +1804,7 @@ def update_debt(
 ) -> uint256:
     """
     @notice Update the debt for a strategy.
+    @dev Pass max uint256 to allocate as much idle as possible.
     @param strategy The strategy to update the debt for.
     @param target_debt The target debt for the strategy.
     @param max_loss Optional to check realized losses on debt decreases.

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -217,7 +217,7 @@ strategies: public(HashMap[address, StrategyParams])
 default_queue: public(DynArray[address, MAX_QUEUE])
 # Should the vault use the default_queue regardless whats passed in.
 use_default_queue: public(bool)
-# Should automatically allocate funds to the first strategy in queue.
+# Should the vault automatically allocate funds to the first strategy in queue.
 auto_allocate: public(bool)
 
 ### ACCOUNTING ###

--- a/tests/unit/vault/test_auto_allocate.py
+++ b/tests/unit/vault/test_auto_allocate.py
@@ -1,0 +1,437 @@
+import ape
+import pytest
+from utils.constants import DAY
+
+
+def test_deposit__auto_update_debt(
+    asset, fish, fish_amount, gov, vault, strategy, user_deposit
+):
+    assets = fish_amount
+
+    assert vault.auto_allocate() == False
+
+    vault.set_auto_allocate(True, sender=gov)
+    vault.update_max_debt_for_strategy(strategy, assets * 2, sender=gov)
+
+    assert vault.auto_allocate()
+    assert strategy.maxDeposit(vault) > assets
+    assert vault.strategies(strategy)["max_debt"] > assets
+    assert vault.minimum_total_idle() == 0
+
+    assert vault.totalAssets() == 0
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == 0
+    assert strategy.totalAssets() == 0
+    assert strategy.balanceOf(vault) == 0
+    assert vault.strategies(strategy)["current_debt"] == 0
+    assert vault.balanceOf(fish) == 0
+
+    asset.approve(vault, assets, sender=fish)
+
+    tx = vault.deposit(assets, fish, sender=fish)
+
+    event = tx.decode_logs(vault.DebtUpdated)
+
+    assert len(event) == 1
+    event = event[0]
+
+    assert event.strategy == strategy
+    assert event.current_debt == 0
+    assert event.new_debt == assets
+
+    assert vault.totalAssets() == assets
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == assets
+    assert strategy.totalAssets() == assets
+    assert strategy.balanceOf(vault) == assets
+    assert vault.strategies(strategy)["current_debt"] == assets
+    assert vault.balanceOf(fish) == assets
+
+
+def test_mint__auto_update_debt(
+    asset, fish, fish_amount, gov, vault, strategy, user_deposit
+):
+    assets = fish_amount
+
+    assert vault.auto_allocate() == False
+
+    vault.set_auto_allocate(True, sender=gov)
+    vault.update_max_debt_for_strategy(strategy, assets * 2, sender=gov)
+
+    assert vault.auto_allocate()
+    assert strategy.maxDeposit(vault) > assets
+    assert vault.strategies(strategy)["max_debt"] > assets
+    assert vault.minimum_total_idle() == 0
+
+    assert vault.totalAssets() == 0
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == 0
+    assert strategy.totalAssets() == 0
+    assert strategy.balanceOf(vault) == 0
+    assert vault.strategies(strategy)["current_debt"] == 0
+    assert vault.balanceOf(fish) == 0
+
+    asset.approve(vault, assets, sender=fish)
+
+    tx = vault.mint(assets, fish, sender=fish)
+
+    event = tx.decode_logs(vault.DebtUpdated)
+
+    assert len(event) == 1
+    event = event[0]
+
+    assert event.strategy == strategy
+    assert event.current_debt == 0
+    assert event.new_debt == assets
+
+    assert vault.totalAssets() == assets
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == assets
+    assert strategy.totalAssets() == assets
+    assert strategy.balanceOf(vault) == assets
+    assert vault.strategies(strategy)["current_debt"] == assets
+    assert vault.balanceOf(fish) == assets
+
+
+def test_deposit__auto_update_debt__max_debt(
+    asset, fish, fish_amount, gov, vault, strategy, user_deposit
+):
+    assets = fish_amount
+    max_debt = assets // 10
+
+    assert vault.auto_allocate() == False
+
+    vault.set_auto_allocate(True, sender=gov)
+    vault.update_max_debt_for_strategy(strategy, max_debt, sender=gov)
+
+    assert vault.auto_allocate()
+    assert strategy.maxDeposit(vault) > assets
+    assert vault.strategies(strategy)["max_debt"] < assets
+    assert vault.minimum_total_idle() == 0
+
+    assert vault.totalAssets() == 0
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == 0
+    assert strategy.totalAssets() == 0
+    assert strategy.balanceOf(vault) == 0
+    assert vault.strategies(strategy)["current_debt"] == 0
+    assert vault.balanceOf(fish) == 0
+
+    asset.approve(vault, assets, sender=fish)
+
+    tx = vault.deposit(assets, fish, sender=fish)
+
+    event = tx.decode_logs(vault.DebtUpdated)
+
+    assert len(event) == 1
+    event = event[0]
+
+    assert event.strategy == strategy
+    assert event.current_debt == 0
+    assert event.new_debt == max_debt
+
+    assert vault.totalAssets() == assets
+    assert vault.totalIdle() == assets - max_debt
+    assert vault.totalDebt() == max_debt
+    assert strategy.totalAssets() == max_debt
+    assert strategy.balanceOf(vault) == max_debt
+    assert vault.strategies(strategy)["current_debt"] == max_debt
+    assert vault.balanceOf(fish) == assets
+
+
+def test_deposit__auto_update_debt__max_deposit(
+    asset, fish, fish_amount, gov, vault, strategy, user_deposit
+):
+    assets = fish_amount
+    max_deposit = assets // 10
+
+    assert vault.auto_allocate() == False
+
+    vault.set_auto_allocate(True, sender=gov)
+    vault.update_max_debt_for_strategy(strategy, 2**256 - 1, sender=gov)
+    strategy.setMaxDebt(max_deposit, sender=gov)
+
+    assert vault.auto_allocate()
+    assert strategy.maxDeposit(vault) == max_deposit
+    assert vault.strategies(strategy)["max_debt"] > assets
+    assert vault.minimum_total_idle() == 0
+
+    assert vault.totalAssets() == 0
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == 0
+    assert strategy.totalAssets() == 0
+    assert strategy.balanceOf(vault) == 0
+    assert vault.strategies(strategy)["current_debt"] == 0
+    assert vault.balanceOf(fish) == 0
+
+    asset.approve(vault, assets, sender=fish)
+
+    tx = vault.deposit(assets, fish, sender=fish)
+
+    event = tx.decode_logs(vault.DebtUpdated)
+
+    assert len(event) == 1
+    event = event[0]
+
+    assert event.strategy == strategy
+    assert event.current_debt == 0
+    assert event.new_debt == max_deposit
+
+    assert vault.totalAssets() == assets
+    assert vault.totalIdle() == assets - max_deposit
+    assert vault.totalDebt() == max_deposit
+    assert strategy.totalAssets() == max_deposit
+    assert strategy.balanceOf(vault) == max_deposit
+    assert vault.strategies(strategy)["current_debt"] == max_deposit
+    assert vault.balanceOf(fish) == assets
+
+
+def test_deposit__auto_update_debt__max_deposit_zero(
+    asset, fish, fish_amount, gov, vault, strategy, user_deposit
+):
+    assets = fish_amount
+    max_deposit = 0
+
+    assert vault.auto_allocate() == False
+
+    vault.set_auto_allocate(True, sender=gov)
+    vault.update_max_debt_for_strategy(strategy, 2**256 - 1, sender=gov)
+    strategy.setMaxDebt(max_deposit, sender=gov)
+
+    assert vault.auto_allocate()
+    assert strategy.maxDeposit(vault) == max_deposit
+    assert vault.strategies(strategy)["max_debt"] > assets
+    assert vault.minimum_total_idle() == 0
+
+    assert vault.totalAssets() == 0
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == 0
+    assert strategy.totalAssets() == 0
+    assert strategy.balanceOf(vault) == 0
+    assert vault.strategies(strategy)["current_debt"] == 0
+    assert vault.balanceOf(fish) == 0
+
+    asset.approve(vault, assets, sender=fish)
+
+    tx = vault.deposit(assets, fish, sender=fish)
+
+    event = tx.decode_logs(vault.DebtUpdated)
+
+    assert len(event) == 0
+
+    assert vault.totalAssets() == assets
+    assert vault.totalIdle() == assets - max_deposit
+    assert vault.totalDebt() == max_deposit
+    assert strategy.totalAssets() == max_deposit
+    assert strategy.balanceOf(vault) == max_deposit
+    assert vault.strategies(strategy)["current_debt"] == max_deposit
+    assert vault.balanceOf(fish) == assets
+
+
+def test_deposit__auto_update_debt__min_idle(
+    asset, fish, fish_amount, gov, vault, strategy, user_deposit
+):
+    assets = fish_amount
+    min_idle = assets // 10
+
+    assert vault.auto_allocate() == False
+
+    vault.set_auto_allocate(True, sender=gov)
+    vault.update_max_debt_for_strategy(strategy, 2**256 - 1, sender=gov)
+    vault.set_minimum_total_idle(min_idle, sender=gov)
+
+    assert vault.auto_allocate()
+    assert strategy.maxDeposit(vault) > assets
+    assert vault.strategies(strategy)["max_debt"] > assets
+    assert vault.minimum_total_idle() == min_idle
+
+    assert vault.totalAssets() == 0
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == 0
+    assert strategy.totalAssets() == 0
+    assert strategy.balanceOf(vault) == 0
+    assert vault.strategies(strategy)["current_debt"] == 0
+    assert vault.balanceOf(fish) == 0
+
+    asset.approve(vault, assets, sender=fish)
+
+    tx = vault.deposit(assets, fish, sender=fish)
+
+    event = tx.decode_logs(vault.DebtUpdated)
+
+    assert len(event) == 1
+    event = event[0]
+
+    assert event.strategy == strategy
+    assert event.current_debt == 0
+    assert event.new_debt == assets - min_idle
+
+    assert vault.totalAssets() == assets
+    assert vault.totalIdle() == min_idle
+    assert vault.totalDebt() == assets - min_idle
+    assert strategy.totalAssets() == assets - min_idle
+    assert strategy.balanceOf(vault) == assets - min_idle
+    assert vault.strategies(strategy)["current_debt"] == assets - min_idle
+    assert vault.balanceOf(fish) == assets
+
+
+def test_deposit__auto_update_debt__min_idle(
+    asset, fish, fish_amount, gov, vault, strategy, user_deposit
+):
+    assets = fish_amount
+    min_idle = assets // 10
+
+    assert vault.auto_allocate() == False
+
+    vault.set_auto_allocate(True, sender=gov)
+    vault.update_max_debt_for_strategy(strategy, 2**256 - 1, sender=gov)
+    vault.set_minimum_total_idle(min_idle, sender=gov)
+
+    assert vault.auto_allocate()
+    assert strategy.maxDeposit(vault) > assets
+    assert vault.strategies(strategy)["max_debt"] > assets
+    assert vault.minimum_total_idle() == min_idle
+
+    assert vault.totalAssets() == 0
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == 0
+    assert strategy.totalAssets() == 0
+    assert strategy.balanceOf(vault) == 0
+    assert vault.strategies(strategy)["current_debt"] == 0
+    assert vault.balanceOf(fish) == 0
+
+    asset.approve(vault, assets, sender=fish)
+
+    tx = vault.deposit(assets, fish, sender=fish)
+
+    event = tx.decode_logs(vault.DebtUpdated)
+
+    assert len(event) == 1
+    event = event[0]
+
+    assert event.strategy == strategy
+    assert event.current_debt == 0
+    assert event.new_debt == assets - min_idle
+
+    assert vault.totalAssets() == assets
+    assert vault.totalIdle() == min_idle
+    assert vault.totalDebt() == assets - min_idle
+    assert strategy.totalAssets() == assets - min_idle
+    assert strategy.balanceOf(vault) == assets - min_idle
+    assert vault.strategies(strategy)["current_debt"] == assets - min_idle
+    assert vault.balanceOf(fish) == assets
+
+
+def test_deposit__auto_update_debt__min_idle_not_met(
+    asset, fish, fish_amount, gov, vault, strategy, user_deposit
+):
+    assets = fish_amount
+    min_idle = assets * 2
+
+    assert vault.auto_allocate() == False
+
+    vault.set_auto_allocate(True, sender=gov)
+    vault.update_max_debt_for_strategy(strategy, 2**256 - 1, sender=gov)
+    vault.set_minimum_total_idle(min_idle, sender=gov)
+
+    assert vault.auto_allocate()
+    assert strategy.maxDeposit(vault) > assets
+    assert vault.strategies(strategy)["max_debt"] > assets
+    assert vault.minimum_total_idle() == min_idle
+
+    assert vault.totalAssets() == 0
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == 0
+    assert strategy.totalAssets() == 0
+    assert strategy.balanceOf(vault) == 0
+    assert vault.strategies(strategy)["current_debt"] == 0
+    assert vault.balanceOf(fish) == 0
+
+    asset.approve(vault, assets, sender=fish)
+
+    tx = vault.deposit(assets, fish, sender=fish)
+
+    event = tx.decode_logs(vault.DebtUpdated)
+
+    assert len(event) == 0
+
+    assert vault.totalAssets() == assets
+    assert vault.totalIdle() == assets
+    assert vault.totalDebt() == 0
+    assert strategy.totalAssets() == 0
+    assert strategy.balanceOf(vault) == 0
+    assert vault.strategies(strategy)["current_debt"] == 0
+    assert vault.balanceOf(fish) == assets
+
+
+def test_deposit__auto_update_debt__current_debt_more_than_max_debt(
+    asset, fish, fish_amount, gov, vault, strategy, user_deposit
+):
+    assets = fish_amount // 2
+    max_debt = assets
+
+    assert vault.auto_allocate() == False
+
+    vault.set_auto_allocate(True, sender=gov)
+    vault.update_max_debt_for_strategy(strategy, max_debt, sender=gov)
+
+    assert vault.auto_allocate()
+    assert strategy.maxDeposit(vault) > assets
+    assert vault.strategies(strategy)["max_debt"] == assets
+    assert vault.minimum_total_idle() == 0
+
+    assert vault.totalAssets() == 0
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == 0
+    assert strategy.totalAssets() == 0
+    assert strategy.balanceOf(vault) == 0
+    assert vault.strategies(strategy)["current_debt"] == 0
+    assert vault.balanceOf(fish) == 0
+
+    asset.approve(vault, assets, sender=fish)
+
+    tx = vault.deposit(assets, fish, sender=fish)
+
+    event = tx.decode_logs(vault.DebtUpdated)
+
+    assert len(event) == 1
+    event = event[0]
+
+    assert event.strategy == strategy
+    assert event.current_debt == 0
+    assert event.new_debt == max_debt
+
+    assert vault.totalAssets() == assets
+    assert vault.totalIdle() == 0
+    assert vault.totalDebt() == max_debt
+    assert strategy.totalAssets() == max_debt
+    assert strategy.balanceOf(vault) == max_debt
+    assert vault.strategies(strategy)["current_debt"] == max_debt
+    assert vault.balanceOf(fish) == assets
+
+    profit = assets // 10
+    # Report profit to go over max debt
+    asset.mint(strategy, profit, sender=gov)
+    strategy.report(sender=gov)
+    vault.process_report(strategy, sender=gov)
+
+    assert (
+        vault.strategies(strategy)["current_debt"]
+        > vault.strategies(strategy)["max_debt"]
+    )
+
+    asset.approve(vault, assets, sender=fish)
+
+    tx = vault.deposit(assets, fish, sender=fish)
+
+    event = tx.decode_logs(vault.DebtUpdated)
+
+    assert len(event) == 0
+
+    assert vault.totalAssets() == assets * 2 + profit
+    assert vault.totalIdle() == assets
+    assert vault.totalDebt() == max_debt + profit
+    assert strategy.totalAssets() == max_debt + profit
+    assert strategy.balanceOf(vault) == max_debt
+    assert vault.strategies(strategy)["current_debt"] == max_debt + profit
+    assert vault.balanceOf(fish) > assets

--- a/tests/unit/vault/test_debt_management.py
+++ b/tests/unit/vault/test_debt_management.py
@@ -96,7 +96,7 @@ def test_update_debt__with_current_debt_equal_to_new_debt__reverts(
         vault.update_debt(strategy.address, new_debt, sender=gov)
 
 
-def test_update_debt__with_current_debt_greater_than_new_debt_and_zero_withdrawable__reverts(
+def test_update_debt__with_current_debt_greater_than_new_debt_and_zero_withdrawable(
     gov, asset, vault, locked_strategy, add_debt_to_strategy
 ):
     vault_balance = asset.balanceOf(vault)
@@ -109,8 +109,9 @@ def test_update_debt__with_current_debt_greater_than_new_debt_and_zero_withdrawa
     # reduce debt in strategy
     vault.update_max_debt_for_strategy(locked_strategy.address, new_debt, sender=gov)
 
-    with ape.reverts("nothing to withdraw"):
-        vault.update_debt(locked_strategy.address, new_debt, sender=gov)
+    tx = vault.update_debt(locked_strategy.address, new_debt, sender=gov)
+
+    assert tx.return_value == current_debt
 
 
 def test_update_debt__with_current_debt_greater_than_new_debt_and_strategy_has_losses__reverts(


### PR DESCRIPTION
## Description

- Add an `auto_allocate` flag to the be set by the DEBT_MANAGER to automatically push all available debt to the first strategy in the queue during every deposit and mint

## Checklist

- [x] I have run vyper and solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch
