### PR TITLE
feat: report on self

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,10 +6,6 @@ on:
     - master
   pull_request:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   tests:
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,10 @@ on:
     - master
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     strategy:

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -1168,6 +1168,9 @@ def _process_report(strategy: address) -> (uint256, uint256):
 
     Any applicable fees are charged and distributed during the report as well
     to the specified recipients.
+
+    Can update the vaults `totalIdle` to account for any airdropped tokens by
+    passing the vaults address in as the parameter.
     """
     # Cache `asset` for repeated use.
     _asset: address = self.asset

--- a/tests/unit/vault/test_vault_accounting.py
+++ b/tests/unit/vault/test_vault_accounting.py
@@ -14,3 +14,39 @@ def test_vault_airdrop_do_not_increase(
     price_per_share = vault.pricePerShare()
     airdrop_asset(gov, asset, vault, int(vault_balance / 10))
     assert vault.pricePerShare() == price_per_share
+
+
+def test_vault_airdrop_do_not_increase_report_records_it(
+    gov, asset, vault, mint_and_deposit_into_vault, airdrop_asset
+):
+    mint_and_deposit_into_vault(vault, gov)
+    vault_balance = asset.balanceOf(vault)
+    assert vault_balance != 0
+    # vault.
+    # aidrop to vault
+    price_per_share = vault.pricePerShare()
+
+    to_airdrop = int(vault_balance / 10)
+    airdrop_asset(gov, asset, vault, to_airdrop)
+
+    assert vault.pricePerShare() == price_per_share
+    assert vault.totalIdle() == vault_balance
+    assert asset.balanceOf(vault) == vault_balance + to_airdrop
+
+    tx = vault.process_report(vault.address, sender=gov)
+
+    event = list(tx.decode_logs(vault.StrategyReported))[0]
+
+    assert event.strategy == vault.address
+    assert event.gain == to_airdrop
+    assert event.loss == 0
+    assert event.current_debt == vault_balance + to_airdrop
+    assert event.total_fees == 0
+
+    # Profit is locked
+    assert vault.pricePerShare() == price_per_share
+    assert vault.totalIdle() == vault_balance + to_airdrop
+    assert asset.balanceOf(vault) == vault_balance + to_airdrop
+
+    chain.pending_timestamp = chain.pending_timestamp + vault.profitMaxUnlockTime() - 1
+    chain.mine(timestamp=chain.pending_timestamp)


### PR DESCRIPTION
## Description

Allow for a report to be processed with the vaults address sent to `process_report` that will account for any loose asset airdropped to the vault

Fixes # (issue)

## Checklist

- [ ] I have run vyper and solidity linting
- [ ] I have run the tests on my machine
- [ ] I have followed commitlint guidelines
- [ ] I have rebased my changes to the latest version of the main branch
