### PR TITLE
feat: update name and symbol

### DIFF
--- a/TECH_SPEC.md
+++ b/TECH_SPEC.md
@@ -45,6 +45,8 @@ When deploying a new vault, it requires the following parameters:
 - role_manager: account that can assign and revoke Roles
 - profit_max_unlock_time: max amount of time profit will be locked before being distributed
 
+All deployment variables besides the `asset` can be updated post deployment.
+
 ## Normal Operation
 
 ### Deposits / Mints

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -1344,6 +1344,27 @@ def _process_report(strategy: address) -> (uint256, uint256):
     return (gain, loss)
 
 # SETTERS #
+
+@external
+def setName(name: String[64]):
+    """
+    @notice Change the vault name.
+    @dev Can only be called by the Role Manager.
+    @param name The new name for the vault.
+    """
+    assert msg.sender == self.role_manager, "not allowed"
+    self.name = name
+
+@external
+def setSymbol(symbol: String[32]):
+    """
+    @notice Change the vault name.
+    @dev Can only be called by the Role Manager.
+    @param symbol The new name for the vault.
+    """
+    assert msg.sender == self.role_manager, "not allowed"
+    self.symbol = symbol
+
 @external
 def set_accountant(new_accountant: address):
     """

--- a/tests/unit/vault/test_role_base_access.py
+++ b/tests/unit/vault/test_role_base_access.py
@@ -684,3 +684,43 @@ def test__remove_role__wont_add(gov, vault, bunny, strategy):
 
     with ape.reverts("not allowed"):
         vault.add_strategy(strategy, sender=bunny)
+
+
+def test__set_name(gov, vault, bunny):
+    name = vault.name()
+    new_name = "New Vault Name"
+
+    with ape.reverts("not allowed"):
+        vault.setName(new_name, sender=bunny)
+
+    vault.set_role(bunny, ROLES.ALL, sender=gov)
+
+    with ape.reverts("not allowed"):
+        vault.setName(new_name, sender=bunny)
+
+    assert vault.name() != new_name
+
+    vault.setName(new_name, sender=gov)
+
+    assert vault.name() == new_name
+    assert vault.name() != name
+
+
+def test__set_symbol(gov, vault, bunny):
+    symbol = vault.name()
+    new_symbol = "New Vault symbol"
+
+    with ape.reverts("not allowed"):
+        vault.setSymbol(new_symbol, sender=bunny)
+
+    vault.set_role(bunny, ROLES.ALL, sender=gov)
+
+    with ape.reverts("not allowed"):
+        vault.setSymbol(new_symbol, sender=bunny)
+
+    assert vault.symbol() != new_symbol
+
+    vault.setSymbol(new_symbol, sender=gov)
+
+    assert vault.symbol() == new_symbol
+    assert vault.symbol() != symbol


### PR DESCRIPTION
## Description

- Allow Role Manager to update the name and the symbol
- Does not emit an event
- Should we change the `salt` the factory uses to not use name and symbol now?

Fixes # (issue)

## Checklist

- [ ] I have run vyper and solidity linting
- [ ] I have run the tests on my machine
- [ ] I have followed commitlint guidelines
- [ ] I have rebased my changes to the latest version of the main branch
