### PR TITLE
docs: fix broken URL 'bloc' to 'blob' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ ape run scripts/deploy.py --network YOUR_RPC_URL
 
 If the deployments do not end at the same address you can also manually send the calldata used in the previous deployments on other chains.
 
-### To make a contribution please follow the [guidelines](https://github.com/yearn/yearn-vaults-v3/bloc/master/CONTRIBUTING.md)
+### To make a contribution please follow the [guidelines](https://github.com/yearn/yearn-vaults-v3/blob/master/CONTRIBUTING.md)
 
 See the ApeWorx [documentation](https://docs.apeworx.io/ape/stable/) and [github](https://github.com/ApeWorX/ape) for more information.
 


### PR DESCRIPTION
## Summary
- Fixed broken GitHub URL in README.md: 'bloc' -> 'blob'
- The CONTRIBUTING.md link was not working due to this typo

## Test plan
- [x] Verified the URL now correctly points to the CONTRIBUTING.md file