### PR TITLE
docs: fix grammar 'are be' to 'are to be' in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ git pull origin master
 
 ```
 
-To stage the changed files that are be committed, issue the command:
+To stage the changed files that are to be committed, issue the command:
 
 ```bash
 git add -a


### PR DESCRIPTION
## Summary
- Fixed grammatical error in CONTRIBUTING.md: "that are be committed" -> "that are to be committed"

## Test plan
- [x] Verified the sentence is now grammatically correct