### PR TITLE
docs: fix grammar 'are have been' to 'have been' in VaultV3.vy

### DIFF
--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -1608,7 +1608,7 @@ def isShutdown() -> bool:
 def unlockedShares() -> uint256:
     """
     @notice Get the amount of shares that have been unlocked.
-    @return The amount of shares that are have been unlocked.
+    @return The amount of shares that have been unlocked.
     """
     return self._unlocked_shares()
 


### PR DESCRIPTION
Fixed grammatical error in VaultV3.vy docstring

## Summary
- Line 1612: 'that are have been unlocked' -> 'that have been unlocked'
- Removed redundant 'are' from the sentence

## Test plan
- Verified the docstring is now grammatically correct
- No code logic changes, only comment fix