### PR TITLE
docs: fix duplicate 'the the' to 'the' in VaultV3.vy

### DIFF
--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -1972,7 +1972,7 @@ def totalIdle() -> uint256:
 @external
 def totalDebt() -> uint256:
     """
-    @notice Get the the total amount of funds invested
+    @notice Get the total amount of funds invested
     across all strategies.
     @return The current total debt.
     """


### PR DESCRIPTION
Fixed duplicate word in VaultV3.vy docstring

## Summary
- Line 1975: 'Get the the total amount' -> 'Get the total amount'
- Removed duplicate word 'the' from the totalDebt() function docstring

## Test plan
- Verified the docstring is now grammatically correct
- No code logic changes, only comment fix