### PR TITLE
docs: fix duplicate 'the the' to 'the' in USDT.sol

### DIFF
--- a/contracts/test/USDT.sol
+++ b/contracts/test/USDT.sol
@@ -176,7 +176,7 @@ abstract contract BasicToken is Ownable, ERC20Basic {
 
     /**
      * @dev Gets the balance of the specified address.
-     * @param _owner The address to query the the balance of.
+     * @param _owner The address to query the balance of.
      * @return balance An uint representing the amount owned by the passed address.
      */
     function balanceOf(


### PR DESCRIPTION
Fixed duplicate word in USDT.sol docstring

## Summary
- Line 179: 'query the the balance' -> 'query the balance'
- Removed duplicate word 'the' from the balanceOf function docstring

## Test plan
- Verified the docstring is now grammatically correct
- No code logic changes, only comment fix