### PR TITLE
docs: fix 'effecting' to 'affecting' in VaultV3.vy comment

### DIFF
--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -1543,7 +1543,7 @@ def add_role(account: address, role: Roles):
     """
     @notice Add a new role/s to an address.
     @dev This will add a new role/s to the account
-     without effecting any of the previously held roles.
+     without affecting any of the previously held roles.
     @param account The account to add a role to.
     @param role The new role/s to add to account.
     """


### PR DESCRIPTION
Fixed word choice error in VaultV3.vy comment

## Summary
- Line 1546: 'without effecting any' -> 'without affecting any'
- 'Affect' is the correct verb meaning 'to have an influence on'
- 'Effect' is typically a noun (or verb meaning 'to bring about')

## Test plan
- Verified the comment is now grammatically correct
- No code logic changes, only comment fix