### PR TITLE
build: v3.1.0

### DIFF
--- a/.github/workflows/foundry.yaml
+++ b/.github/workflows/foundry.yaml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.10'
         
       - name: Install Vyper
-        run: pip install vyper==0.3.7
+        run: pip install vyper==0.3.10
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1

--- a/.github/workflows/foundry.yaml
+++ b/.github/workflows/foundry.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: recursive
         
@@ -30,7 +30,7 @@ jobs:
         run: pip install vyper==0.3.7
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
         with:
           version: nightly
 

--- a/.github/workflows/foundry.yaml
+++ b/.github/workflows/foundry.yaml
@@ -25,6 +25,10 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: recursive
+
+      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
+        with:
+          python-version: '3.10'
         
       - name: Install Vyper
         run: pip install vyper==0.3.7

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,24 +12,24 @@ jobs:
 
       steps:
       - name: Check out github repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           fetch-depth: 0
 
       - name: Run commitlint
-        uses: wagoid/commitlint-github-action@v2
+        uses: wagoid/commitlint-github-action@4b1bcb1c72f99fbd6aa6b34cc3fb59200f01f993 # v2
 
     black:
       runs-on: ubuntu-latest
 
       steps:
       - name: Check out github repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           fetch-depth: 1
 
       - name: Set up python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
         with:
           python-version: 3.9
 
@@ -38,7 +38,7 @@ jobs:
         run: |
             echo "::set-output name=dir::$(pip cache dir)"
       - name: Restore pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         id: pip-cache
         with:
           path: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,10 +28,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up python 3.9
+      - name: Set up python 3.10
         uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
         with:
-          python-version: 3.9
+          python-version: '3.10'
 
       - name: Set pip cache directory path
         id: pip-cache-dir-path

--- a/.github/workflows/slither.yaml
+++ b/.github/workflows/slither.yaml
@@ -9,6 +9,6 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: crytic/slither-action@v0.1.1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: crytic/slither-action@16fe6d29d16c34999bccbd16090a7c7cba6a9c3e # v0.1.1
         continue-on-error: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,14 +20,24 @@ jobs:
 
     steps:
     - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
+
+    - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
       with:
         python-version: '3.10'
 
     - name: install requirements
       run: python3 -m pip install -r requirements.txt 
-    
-    - name: install plugins
-      run: ape plugins install .
+
+    - name: pin ape plugins
+      run: |
+        python3 -m pip install \
+          "eth-ape==0.8.25" \
+          "ape-solidity==0.8.5" \
+          "ape-vyper==0.8.12" \
+          "ape-hardhat==0.8.5"
+
+    - name: install vyper compiler
+      run: ape vyper vvm install 0.3.7
     
     - name: Compile contracts
       # TODO: Force recompiles until ape compile caching is fixed
@@ -39,8 +49,10 @@ jobs:
       with:
         node-version: '18.x'
 
-    - name: Install hardhat
-      run: npm ci hardhat
+    - name: Install node dependencies
+      run: |
+        corepack enable
+        yarn install --frozen-lockfile
 
     - name: output current installation
       run: pip freeze

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
       with:
         python-version: '3.10'
 
@@ -35,12 +35,12 @@ jobs:
 
     # Needed to use hardhat
     - name: Setup node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
       with:
         node-version: '18.x'
 
     - name: Install hardhat
-      run: npm install hardhat
+      run: npm ci hardhat
 
     - name: output current installation
       run: pip freeze

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
     - name: pin ape plugins
       run: |
         python3 -m pip install \
-          "eth-ape==0.8.25" \
+          "eth-ape==0.8.10" \
           "ape-solidity==0.8.5" \
           "ape-vyper==0.8.12" \
           "ape-hardhat==0.8.5"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
           "ape-hardhat==0.8.5"
 
     - name: install vyper compiler
-      run: ape vyper vvm install 0.3.7
+      run: ape vyper vvm install 0.3.10
     
     - name: Compile contracts
       # TODO: Force recompiles until ape compile caching is fixed

--- a/.gitmodules
+++ b/.gitmodules
@@ -11,4 +11,4 @@
 [submodule "lib/tokenized-strategy"]
 	path = lib/tokenized-strategy
 	url = https://github.com/yearn/tokenized-strategy
-	branch = v3.0.3
+	branch = v3.0.4

--- a/.solhint.json
+++ b/.solhint.json
@@ -1,6 +1,6 @@
 {
   "extends": "solhint:recommended",
-  "plugins": ["prettier", "yearn"],
+  "plugins": ["prettier"],
   "rules": {
     "compiler-version": ["error", "0.8.18"],
     "code-complexity": "warn",
@@ -14,7 +14,6 @@
     "avoid-sha3": "warn",
     "not-rely-on-time": "off",
     "private-vars-leading-underscore": "warn",
-    "reason-string": ["warn", { "maxLength": 64 }],
-    "yearn/underscore-function-args": "off"
+    "reason-string": ["warn", { "maxLength": 64 }]
   }
 }

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,3 @@
+npmMinimalAgeGate: 10080
+enableScripts: false
+defaultSemverRangePrefix: ""

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ git pull origin master
 
 ```
 
-To stage the changed files that are be committed, issue the command:
+To stage the changed files that are being committed, issue the command:
 
 ```bash
 git add -a
@@ -46,10 +46,10 @@ git add -a
 Once you are ready to make a commit, you can do so with:
 
 ```bash
-git commit  -m “fix: message to explain what the commit covers”
+git commit -m "fix: message to explain what the commit covers"
 ```
 
-**NOTE**: commit message must follow Conventional Commits [standard](https://www.conventionalcommits.org/en/v1.0.0/), otherwise your pull requests (discussed further below below) will not pass validation tests. You can use the [`--amend` flag](https://git-scm.com/docs/git-commit) to effectively change your commit message.
+**NOTE**: commit message must follow Conventional Commits [standard](https://www.conventionalcommits.org/en/v1.0.0/), otherwise your pull requests will not pass validation tests. You can use the [`--amend` flag](https://git-scm.com/docs/git-commit) to effectively change your commit message.
 
 ### Handling conflicts
 
@@ -71,7 +71,7 @@ Your version of the conflicting code
 
 The code from the yearn-vaults-v3 repository is inserted between `<<<` and `===` while the change you have made is inserted between `===` and `>>>>`. Remove everything between `<<<<` and `>>>` and replace it with code that resolves the conflict. Repeat the process for all files listed by Git status to have conflicts.
 
-When you are ready, use git push to move your local copy of the changes to your fork of the repository on Github.
+When you are ready, use git push to move your local copy of the changes to your fork of the repository on GitHub.
 
 ```bash
 git push git@github.com:<your_github_username>/yearn-vaults-v3.git feature-in-progress-branch
@@ -79,7 +79,7 @@ git push git@github.com:<your_github_username>/yearn-vaults-v3.git feature-in-pr
 
 ### Opening a pull request
 
-Navigate to your fork of the repository on Github. In the upper left where the current branch is listed, change the branch to your newly created one (feature-in-progress-branch). Open the files that you have worked on and ensure they include your changes.
+Navigate to your fork of the repository on GitHub. In the upper left where the current branch is listed, change the branch to your newly created one (feature-in-progress-branch). Open the files that you have worked on and ensure they include your changes.
 
 Navigate to yearn-vaults-v3 [repository](https://github.com/yearn/yearn-vaults-v3/tree/master) and click on the new pull request button. In the “base” box on the left, leave the default selection “base master”, the branch that you want your changes to be applied to. In the “compare” box on the right, select the branch containing the changes you want to apply. You will then be asked to answer a few questions about your pull request. Pull requests should have enough context about what you are working on, how you are solving a problem, and reference all necessary information for your reviewers to help.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Yearn V3 Vaults
 
-This repository contains the Smart Contracts for Yearns V3 vault implementation.
+This repository contains the smart contracts for Yearn's V3 vault implementation.
 
 [VaultFactory.vy](contracts/VaultFactory.vy) - The base factory that all vaults will be deployed from and used to configure protocol fees
 
-[Vault.vy](contracts/VaultV3.vy) - The ERC4626 compliant Vault that will handle all logic associated with deposits, withdraws, strategy management, profit reporting etc.
+[VaultV3.vy](contracts/VaultV3.vy) - The ERC4626 compliant Vault that will handle all logic associated with deposits, withdrawals, strategy management, profit reporting etc.
 
 For the most updated deployment addresses see the [docs](https://docs.yearn.fi/developers/addresses/v3-contracts). And read more about V3 and how to manage your own multi strategy vault here https://docs.yearn.fi/developers/v3/overview
 
@@ -20,7 +20,7 @@ You will need:
  - [Foundry](https://book.getfoundry.sh/getting-started/installation)
  - Linux or macOS
  - Windows: Install Windows Subsystem Linux (WSL) with Python 3.8 or later
- - [Hardhat](https://hardhat.org/) installed globally
+ - [Hardhat](https://hardhat.org/)
 
 ## Installation
 
@@ -72,7 +72,7 @@ forge test
 
 ## Deployment
 
-Deployments of the Vault Factory are done using create2 to be at a deterministic address on any EVM chain.
+Deployments of the Vault Factory are done using CREATE2 through the deterministic deployer at `0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed`.
 
 Check the [docs](https://docs.yearn.fi/developers/addresses/v3-contracts) for the most updated deployment address.
 
@@ -81,9 +81,28 @@ Deployments on new chains can be done permissionlessly by anyone using the inclu
 ape run scripts/deploy.py --network YOUR_RPC_URL
 ```
 
+The script currently uses raw salt `0x0000000000000000000000000000000000000000000000000000000000004b62`. The deterministic deployer hashes this raw salt before CREATE2. With the current bytecode and constructor args, the expected addresses are:
+
+```
+Vault original: 0xdD3FA86409658d207A9BE0141eE560C8db557824
+Vault Factory:  0x310aC28ACF5E514abDbFF9Ab25e21f1bfe22bcAC
+```
+
+To dry run against a mainnet fork, start Hardhat in one terminal:
+
+```
+npx hardhat node --fork YOUR_RPC_URL
+```
+
+Then run the deploy script against the local fork in another terminal:
+
+```
+ape run scripts/deploy.py --network ethereum:local:hardhat
+```
+
 If the deployments do not end at the same address you can also manually send the calldata used in the previous deployments on other chains.
 
-### To make a contribution please follow the [guidelines](https://github.com/yearn/yearn-vaults-v3/bloc/master/CONTRIBUTING.md)
+### To make a contribution please follow the [guidelines](https://github.com/yearn/yearn-vaults-v3/blob/master/CONTRIBUTING.md)
 
 See the ApeWorx [documentation](https://docs.apeworx.io/ape/stable/) and [github](https://github.com/ApeWorX/ape) for more information.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository runs on [ApeWorx](https://www.apeworx.io/). A python based devel
 
 You will need:
  - Python 3.8 or later
- - [Vyper 0.3.7](https://docs.vyperlang.org/en/stable/installing-vyper.html)
+ - [Vyper 0.3.10](https://docs.vyperlang.org/en/stable/installing-vyper.html)
  - [Foundry](https://book.getfoundry.sh/getting-started/installation)
  - Linux or macOS
  - Windows: Install Windows Subsystem Linux (WSL) with Python 3.8 or later

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,6 @@ For full security process refer to yearn-security [repo](https://github.com/year
 
 ## Scope
 
-The scope of the Bug Bounty program spans smart contracts utilized in the Yearn ecosystem – including but not limited to the main [VaultV3.vy](https://github.com/yearn/yearn-vaults-v3/blob/master/contracts/VaultV3.vy) and [VaultFactory.vy](https://github.com/yearn/yearn-vaults-v3/blob/master/contracts/VaultV3.vy) Vyper contracts in this repo, including historical deployments that still see active use associated with Yearn, and excluding any contracts used in a test-only capacity (including test-only deployments).
+The scope of the Bug Bounty program spans smart contracts utilized in the Yearn ecosystem – including but not limited to the main [VaultV3.vy](https://github.com/yearn/yearn-vaults-v3/blob/master/contracts/VaultV3.vy) and [VaultFactory.vy](https://github.com/yearn/yearn-vaults-v3/blob/master/contracts/VaultFactory.vy) Vyper contracts in this repo, including historical deployments that still see active use associated with Yearn, and excluding any contracts used in a test-only capacity (including test-only deployments).
 
 Note: Other contracts, outside of the ones mentioned above, might be considered on a case by case basis, please, reach out to the Yearn development team for clarification.

--- a/TECH_SPEC.md
+++ b/TECH_SPEC.md
@@ -8,7 +8,7 @@
 - Vault: ERC4626 compliant Smart contract that receives Assets from Depositors to then distribute them among the different Strategies added to the vault, managing accounting and Assets distribution. 
 - Role: the different flags an Account can have in the Vault so that the Account can do certain specific actions. Can be fulfilled by a smart contract or an EOA.
 - Accountant: smart contract that receives P&L reporting and returns shares and refunds to the strategy
-- Limit Modules: Add on smart contracts that can control the vaults deposit and withdraw limits dynamically.
+- Hooks: Add on smart contracts that can control vault deposit and withdraw limits dynamically and receive post-deposit or post-withdraw callbacks.
 
 # VaultV3 Specification
 The Vault code has been designed as an non-opinionated system to distribute funds of depositors into different opportunities (aka Strategies) and manage accounting in a robust way. That's all.
@@ -30,7 +30,7 @@ Example periphery contracts:
 - Role Manager: Governance contract that holds the vaults `role_manager` position to codify vault setup and ownership guidelines. (see [RoleManager](https://github.com/yearn/vault-periphery/tree/master/contracts/Managers))
 - Debt Allocator: a smart contract that optimizes between multiple strategies based on the optimal return. (see [DebAllocators](https://github.com/yearn/vault-periphery/tree/master/contracts/debtAllocators))
 - Safety Staking Module: a smart contract that allows players to sponsor specific strategies (so that they are added to the vault) by staking their YFI, making money if they do well and losing money if they don't.
-- Deposit Limit Module: Will dynamically adjust the deposit limit based on the depositor and arbitrary conditions.
+- Deposit Hook: Will dynamically adjust the deposit limit based on the depositor and arbitrary conditions, and can react after deposits.
 - ...
 ```
 ## Deployment
@@ -52,7 +52,7 @@ All deployment variables besides the `asset` can be updated post deployment.
 ### Deposits / Mints
 Users can deposit ASSET tokens to receive yvTokens (SHARES).
 
-Deposits are limited under depositLimit/depositLimitModule and shutdown parameters. Read below for details.
+Deposits are limited under depositLimit/depositHook and shutdown parameters. Read below for details.
 
 ### Withdrawals / Redeems
 Users can redeem their shares at any point in time if there is liquidity available. 
@@ -118,8 +118,8 @@ These are:
 - REPORTING_MANAGER: role that calls report for strategies
 - DEBT_MANAGER: role that adds and removes debt from strategies
 - MAX_DEBT_MANAGER: role that can set the max debt for a strategy
-- DEPOSIT_LIMIT_MANAGER: role that sets deposit limit or deposit limit module for the vault
-- WITHDRAW_LIMIT_MANAGER: role that sets the withdraw limit module for the vault.
+- DEPOSIT_LIMIT_MANAGER: role that sets deposit limit or deposit hook for the vault
+- WITHDRAW_LIMIT_MANAGER: role that sets the withdraw hook for the vault.
 - MINIMUM_IDLE_MANAGER: role that sets the minimum total idle the vault should keep
 - PROFIT_UNLOCK_MANAGER: role that sets the profit_max_unlock_time
 - DEBT_PURCHASER # can purchase bad debt from the vault
@@ -144,12 +144,12 @@ Revoked strategies will return all debt and stop being eligible to receive more.
 
 Force revoking a strategy is only used in cases of a faulty strategy that cannot otherwise have its current_debt reduced to 0. Force revoking a strategy will result in a loss being reported by the vault.
 
-#### Setting the modules/periphery contracts
+#### Setting the hooks/periphery contracts
 The accountant can be set by the ACCOUNTANT_MANAGER.
 
-A deposit_limit_module can be set by the DEPOSIT_LIMIT_MANAGER
+A deposit_hook can be set by the DEPOSIT_LIMIT_MANAGER
 
-A withdraw_limit_module can be set by the WITHDRAW_LIMIT_MANAGER
+A withdraw_hook can be set by the WITHDRAW_LIMIT_MANAGER
 
 These contracts are not needed for the vault to function but are optional add ons for optimal use.
 
@@ -186,16 +186,16 @@ Stored in strategies[strategy].max_debt
 When a debt re-balance is triggered, the Vault will cap the new target debt to this number (max_debt)
 
 #### Setting the deposit limit
-The DEPOSIT_LIMIT_MANAGER is in charge of setting the deposit_limit or a deposit_limit_module for the vault
+The DEPOSIT_LIMIT_MANAGER is in charge of setting the deposit_limit or a deposit_hook for the vault
 
 On deployment deposit_limit defaults to 0 and will need to be increased to make the vault functional
 
-The deposit_limit will have to be set to MAX_UINT256 in order to set a deposit_limit_module, and the module will have to be address 0 to adjust the deposit_limit. Or the DEPOSIT_LIMIT_MANAGER can use the option `override` flags to do this in one step.
+The deposit_limit will have to be set to MAX_UINT256 in order to set a deposit_hook, and the hook will have to be address 0 to adjust the deposit_limit. Or the DEPOSIT_LIMIT_MANAGER can use the option `override` flags to do this in one step.
 
-#### Setting the withdraw limit module
-The WITHDRAW_LIMIT_MANAGER is in charge of setting the withdraw_limit_module for the vault
+#### Setting the withdraw hook
+The WITHDRAW_LIMIT_MANAGER is in charge of setting the withdraw_hook for the vault
 
-The vaults default withdraw limit is calculated based on the liquidity of its strategies. Setting a withdraw limit module will override this functionality.
+The vaults default withdraw limit is calculated based on the liquidity of its strategies. Setting a withdraw hook will override this functionality.
 
 #### Setting minimum idle funds
 The MINIMUM_IDLE_MANAGER can specify how many funds the vault should try to have reserved to serve withdrawal requests

--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -12,7 +12,7 @@ dependencies:
     ref: 4.9.5
   - name: tokenized-strategy
     github: yearn/tokenized-strategy
-    ref: v3.0.4
+    ref: v3.1.0
     config_override:
       contracts_folder: src
 

--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -24,6 +24,9 @@ solidity:
   import_remapping:
     - "@openzeppelin=contracts/.cache/openzeppelin/v4.9.5"
 
+vyper:
+  evm_version: paris
+
 ethereum:
   evm_version: paris
   local:

--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -12,12 +12,17 @@ dependencies:
     ref: 4.9.5
   - name: tokenized-strategy
     github: yearn/tokenized-strategy
-    ref: v3.1.0
+    ref: v3.0.4
     config_override:
       contracts_folder: src
+      solidity:
+        import_remapping:
+          - "@openzeppelin=contracts/.cache/openzeppelin/v4.9.5"
 
 solidity:
   version: 0.8.18
+  import_remapping:
+    - "@openzeppelin=contracts/.cache/openzeppelin/v4.9.5"
 
 ethereum:
   evm_version: paris

--- a/contracts/VaultFactory.vy
+++ b/contracts/VaultFactory.vy
@@ -69,7 +69,7 @@ event UpdatePendingGovernance:
 
 
 # Identifier for this version of the vault.
-API_VERSION: constant(String[28]) = "3.0.4"
+API_VERSION: constant(String[28]) = "3.1.0"
 
 # The max amount the protocol fee can be set to.
 MAX_FEE_BPS: constant(uint16) = 5_000 # 50%

--- a/contracts/VaultFactory.vy
+++ b/contracts/VaultFactory.vy
@@ -1,4 +1,5 @@
-# @version 0.3.7
+# @version 0.3.10
+#pragma evm-version paris
 
 """
 @title Yearn Vault Factory

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -51,11 +51,13 @@ interface IStrategy:
 interface IAccountant:
     def report(strategy: address, gain: uint256, loss: uint256) -> (uint256, uint256): nonpayable
 
-interface IDepositLimitModule:
+interface IDepositHook:
     def available_deposit_limit(receiver: address) -> uint256: view
+    def post_deposit(sender: address, receiver: address, assets: uint256, shares: uint256): nonpayable
     
-interface IWithdrawLimitModule:
+interface IWithdrawHook:
     def available_withdraw_limit(owner: address, max_loss: uint256, strategies: DynArray[address, MAX_QUEUE]) -> uint256: view
+    def post_withdraw(sender: address, receiver: address, owner: address, assets: uint256, shares: uint256): nonpayable
 
 interface IFactory:
     def protocol_fee_config() -> (uint16, address): view
@@ -121,11 +123,11 @@ event UpdateRoleManager:
 event UpdateAccountant:
     accountant: indexed(address)
 
-event UpdateDepositLimitModule:
-    deposit_limit_module: indexed(address)
+event UpdateDepositHook:
+    deposit_hook: indexed(address)
 
-event UpdateWithdrawLimitModule:
-    withdraw_limit_module: indexed(address)
+event UpdateWithdrawHook:
+    withdraw_hook: indexed(address)
 
 event UpdateDefaultQueue:
     new_default_queue: DynArray[address, MAX_QUEUE]
@@ -194,8 +196,8 @@ enum Roles:
     REPORTING_MANAGER # Calls report for strategies.
     DEBT_MANAGER # Adds and removes debt from strategies.
     MAX_DEBT_MANAGER # Can set the max debt for a strategy.
-    DEPOSIT_LIMIT_MANAGER # Sets deposit limit and module for the vault.
-    WITHDRAW_LIMIT_MANAGER # Sets the withdraw limit module.
+    DEPOSIT_LIMIT_MANAGER # Sets deposit limit and deposit hook for the vault.
+    WITHDRAW_LIMIT_MANAGER # Sets the withdraw hook.
     MINIMUM_IDLE_MANAGER # Sets the minimum total idle the vault should keep.
     PROFIT_UNLOCK_MANAGER # Sets the profit_max_unlock_time.
     DEBT_PURCHASER # Can purchase bad debt from the vault.
@@ -245,10 +247,10 @@ deposit_limit: public(uint256)
 ### PERIPHERY ###
 # Contract that charges fees and can give refunds.
 accountant: public(address)
-# Contract to control the deposit limit.
-deposit_limit_module: public(address)
-# Contract to control the withdraw limit.
-withdraw_limit_module: public(address)
+# Contract to control the deposit limit and receive post-deposit callbacks.
+deposit_hook: public(address)
+# Contract to control the withdraw limit and receive post-withdraw callbacks.
+withdraw_hook: public(address)
 
 ### ROLES ###
 # HashMap mapping addresses to their roles
@@ -523,10 +525,10 @@ def _max_deposit(receiver: address) -> uint256:
     if receiver in [empty(address), self]:
         return 0
 
-    # If there is a deposit limit module set use that.
-    deposit_limit_module: address = self.deposit_limit_module
-    if deposit_limit_module != empty(address):
-        return IDepositLimitModule(deposit_limit_module).available_deposit_limit(receiver)
+    # If there is a deposit hook set use that.
+    deposit_hook: address = self.deposit_hook
+    if deposit_hook != empty(address):
+        return IDepositHook(deposit_hook).available_deposit_limit(receiver)
     
     # Else use the standard flow.
     _deposit_limit: uint256 = self.deposit_limit
@@ -579,15 +581,15 @@ def _max_withdraw(
     # Get the max amount for the owner if fully liquid.
     max_assets: uint256 = self._convert_to_assets(self.balance_of[owner], Rounding.ROUND_DOWN)
 
-    # If there is a withdraw limit module use that.
-    withdraw_limit_module: address = self.withdraw_limit_module
+    # If there is a withdraw hook use that.
+    withdraw_hook: address = self.withdraw_hook
     # Use the same queue that a redemption would use.
     _strategies: DynArray[address, MAX_QUEUE] = self._withdraw_queue(strategies)
-    if withdraw_limit_module != empty(address):
+    if withdraw_hook != empty(address):
         return min(
             # Use the min between the returned value and the max.
-            # Means the limit module doesn't need to account for balances or conversions.
-            IWithdrawLimitModule(withdraw_limit_module).available_withdraw_limit(owner, max_loss, _strategies),
+            # Means the hook doesn't need to account for balances or conversions.
+            IWithdrawHook(withdraw_hook).available_withdraw_limit(owner, max_loss, _strategies),
             max_assets
         )
     
@@ -680,6 +682,10 @@ def _deposit(recipient: address, assets: uint256, shares: uint256):
     if self.auto_allocate:
         self._update_debt(self.default_queue[0], max_value(uint256), 0)
 
+    deposit_hook: address = self.deposit_hook
+    if deposit_hook != empty(address):
+        IDepositHook(deposit_hook).post_deposit(msg.sender, recipient, assets, shares)
+
 @view
 @internal
 def _assess_share_of_unrealised_losses(strategy: address, strategy_current_debt: uint256, assets_needed: uint256) -> uint256:
@@ -757,12 +763,12 @@ def _redeem(
     assert assets > 0, "no assets to withdraw"
     assert max_loss <= MAX_BPS, "max loss"
     
-    # If there is a withdraw limit module, check the max.
-    withdraw_limit_module: address = self.withdraw_limit_module
+    # If there is a withdraw hook, check the max.
+    withdraw_hook: address = self.withdraw_hook
     _strategies: DynArray[address, MAX_QUEUE] = self._withdraw_queue(strategies)
     
-    if withdraw_limit_module != empty(address):
-        assert assets <= IWithdrawLimitModule(withdraw_limit_module).available_withdraw_limit(owner, max_loss, _strategies), "exceed withdraw limit"
+    if withdraw_hook != empty(address):
+        assert assets <= IWithdrawHook(withdraw_hook).available_withdraw_limit(owner, max_loss, _strategies), "exceed withdraw limit"
 
     assert self.balance_of[owner] >= shares, "insufficient shares to redeem"
     
@@ -916,6 +922,10 @@ def _redeem(
     self._erc20_safe_transfer(_asset, receiver, requested_assets)
 
     log Withdraw(sender, receiver, owner, requested_assets, shares)
+
+    if withdraw_hook != empty(address):
+        IWithdrawHook(withdraw_hook).post_withdraw(sender, receiver, owner, requested_assets, shares)
+
     return requested_assets
 
 ## STRATEGY MANAGEMENT ##
@@ -1420,37 +1430,37 @@ def set_auto_allocate(auto_allocate: bool):
 def set_deposit_limit(deposit_limit: uint256, override: bool = False):
     """
     @notice Set the new deposit limit.
-    @dev Can not be changed if a deposit_limit_module
+    @dev Can not be changed if a deposit_hook
     is set unless the override flag is true or if shutdown.
     @param deposit_limit The new deposit limit.
-    @param override If a `deposit_limit_module` already set should be overridden.
+    @param override If a `deposit_hook` already set should be overridden.
     """
     assert self.shutdown == False # Dev: shutdown
     self._enforce_role(msg.sender, Roles.DEPOSIT_LIMIT_MANAGER)
 
-    # If we are overriding the deposit limit module.
+    # If we are overriding the deposit hook.
     if override:
         # Make sure it is set to address 0 if not already.
-        if self.deposit_limit_module != empty(address):
+        if self.deposit_hook != empty(address):
 
-            self.deposit_limit_module = empty(address)
-            log UpdateDepositLimitModule(empty(address))
+            self.deposit_hook = empty(address)
+            log UpdateDepositHook(empty(address))
     else:  
-        # Make sure the deposit_limit_module has been set to address(0).
-        assert self.deposit_limit_module == empty(address), "using module"
+        # Make sure the deposit_hook has been set to address(0).
+        assert self.deposit_hook == empty(address), "using hook"
 
     self.deposit_limit = deposit_limit
 
     log UpdateDepositLimit(deposit_limit)
 
 @external
-def set_deposit_limit_module(deposit_limit_module: address, override: bool = False):
+def set_deposit_hook(deposit_hook: address, override: bool = False):
     """
-    @notice Set a contract to handle the deposit limit.
+    @notice Set a contract to handle the deposit limit and post-deposit hook.
     @dev The default `deposit_limit` will need to be set to
-    max uint256 since the module will override it or the override flag
+    max uint256 since the hook will override it or the override flag
     must be set to true to set it to max in 1 tx..
-    @param deposit_limit_module Address of the module.
+    @param deposit_hook Address of the hook.
     @param override If a `deposit_limit` already set should be overridden.
     """
     assert self.shutdown == False # Dev: shutdown
@@ -1467,22 +1477,22 @@ def set_deposit_limit_module(deposit_limit_module: address, override: bool = Fal
         # Make sure the deposit_limit has been set to uint max.
         assert self.deposit_limit == max_value(uint256), "using deposit limit"
 
-    self.deposit_limit_module = deposit_limit_module
+    self.deposit_hook = deposit_hook
 
-    log UpdateDepositLimitModule(deposit_limit_module)
+    log UpdateDepositHook(deposit_hook)
 
 @external
-def set_withdraw_limit_module(withdraw_limit_module: address):
+def set_withdraw_hook(withdraw_hook: address):
     """
-    @notice Set a contract to handle the withdraw limit.
+    @notice Set a contract to handle the withdraw limit and post-withdraw hook.
     @dev This will override the default `max_withdraw`.
-    @param withdraw_limit_module Address of the module.
+    @param withdraw_hook Address of the hook.
     """
     self._enforce_role(msg.sender, Roles.WITHDRAW_LIMIT_MANAGER)
 
-    self.withdraw_limit_module = withdraw_limit_module
+    self.withdraw_hook = withdraw_hook
 
-    log UpdateWithdrawLimitModule(withdraw_limit_module)
+    log UpdateWithdrawHook(withdraw_hook)
 
 @external
 def set_minimum_total_idle(minimum_total_idle: uint256):
@@ -1804,10 +1814,10 @@ def shutdown_vault():
     self.shutdown = True
 
     # Set deposit limit to 0.
-    if self.deposit_limit_module != empty(address):
-        self.deposit_limit_module = empty(address)
+    if self.deposit_hook != empty(address):
+        self.deposit_hook = empty(address)
 
-        log UpdateDepositLimitModule(empty(address))
+        log UpdateDepositHook(empty(address))
 
     self.deposit_limit = 0
     log UpdateDepositLimit(0)

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -533,6 +533,18 @@ def _max_deposit(receiver: address) -> uint256:
 
 @view
 @internal
+def _withdraw_queue(strategies: DynArray[address, MAX_QUEUE]) -> DynArray[address, MAX_QUEUE]:
+    """
+    @dev Returns the strategies queue that will be used for a withdrawal.
+    """
+    # If a custom queue was passed, and we don't force the default queue.
+    if len(strategies) != 0 and not self.use_default_queue:
+        return strategies
+
+    return self.default_queue
+
+@view
+@internal
 def _max_withdraw(
     owner: address,
     max_loss: uint256,
@@ -559,11 +571,13 @@ def _max_withdraw(
 
     # If there is a withdraw limit module use that.
     withdraw_limit_module: address = self.withdraw_limit_module
+    # Use the same queue that a redemption would use.
+    _strategies: DynArray[address, MAX_QUEUE] = self._withdraw_queue(strategies)
     if withdraw_limit_module != empty(address):
         return min(
             # Use the min between the returned value and the max.
             # Means the limit module doesn't need to account for balances or conversions.
-            IWithdrawLimitModule(withdraw_limit_module).available_withdraw_limit(owner, max_loss, strategies),
+            IWithdrawLimitModule(withdraw_limit_module).available_withdraw_limit(owner, max_loss, _strategies),
             max_assets
         )
     
@@ -573,14 +587,6 @@ def _max_withdraw(
         # Track how much we can pull.
         have: uint256 = current_idle
         loss: uint256 = 0
-
-        # Cache the default queue.
-        _strategies: DynArray[address, MAX_QUEUE] = self.default_queue
-
-        # If a custom queue was passed, and we don't force the default queue.
-        if len(strategies) != 0 and not self.use_default_queue:
-            # Use the custom queue.
-            _strategies = strategies
 
         for strategy in _strategies:
             # Can't use an invalid strategy.
@@ -742,8 +748,10 @@ def _redeem(
     
     # If there is a withdraw limit module, check the max.
     withdraw_limit_module: address = self.withdraw_limit_module
+    _strategies: DynArray[address, MAX_QUEUE] = self._withdraw_queue(strategies)
+    
     if withdraw_limit_module != empty(address):
-        assert assets <= IWithdrawLimitModule(withdraw_limit_module).available_withdraw_limit(owner, max_loss, strategies), "exceed withdraw limit"
+        assert assets <= IWithdrawLimitModule(withdraw_limit_module).available_withdraw_limit(owner, max_loss, _strategies), "exceed withdraw limit"
 
     assert self.balance_of[owner] >= shares, "insufficient shares to redeem"
     
@@ -760,15 +768,6 @@ def _redeem(
     # If there are not enough assets in the Vault contract, we try to free
     # funds from strategies.
     if requested_assets > current_total_idle:
-
-        # Cache the default queue.
-        _strategies: DynArray[address, MAX_QUEUE] = self.default_queue
-
-        # If a custom queue was passed, and we don't force the default queue.
-        if len(strategies) != 0 and not self.use_default_queue:
-            # Use the custom queue.
-            _strategies = strategies
-
         # load to memory to save gas
         current_total_debt: uint256 = self.total_debt
 

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -1,4 +1,6 @@
-# @version 0.3.7
+# @version 0.3.10
+#pragma evm-version paris
+#pragma optimize codesize
 
 """
 @title Yearn V3 Vault

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -136,6 +136,9 @@ event UpdateUseDefaultQueue:
 event UpdateAutoAllocate:
     auto_allocate: bool
 
+event UpdatePaused:
+    paused: bool
+
 event UpdatedMaxDebtForStrategy:
     sender: indexed(address)
     strategy: indexed(address)
@@ -196,7 +199,7 @@ enum Roles:
     MINIMUM_IDLE_MANAGER # Sets the minimum total idle the vault should keep.
     PROFIT_UNLOCK_MANAGER # Sets the profit_max_unlock_time.
     DEBT_PURCHASER # Can purchase bad debt from the vault.
-    EMERGENCY_MANAGER # Can shutdown vault in an emergency.
+    EMERGENCY_MANAGER # Can shutdown or pause vault in an emergency.
 
 enum StrategyChangeType:
     ADDED
@@ -262,6 +265,8 @@ symbol: public(String[32])
 
 # State of the vault - if set to true, only withdrawals will be available. It can't be reverted.
 shutdown: bool
+# Reversible state that pauses ERC4626 user flows.
+paused: bool
 # The amount of time profits will unlock over.
 profit_max_unlock_time: uint256
 # The timestamp of when the current unlocking period ends.
@@ -512,6 +517,9 @@ def _issue_shares(shares: uint256, recipient: address):
 @view
 @internal
 def _max_deposit(receiver: address) -> uint256: 
+    if self.paused:
+        return 0
+
     if receiver in [empty(address), self]:
         return 0
 
@@ -565,6 +573,8 @@ def _max_withdraw(
     out is 90, but a user of the vault will need to call withdraw with 100
     in order to get the full 90 out.
     """
+    if self.paused:
+        return 0
 
     # Get the max amount for the owner if fully liquid.
     max_assets: uint256 = self._convert_to_assets(self.balance_of[owner], Rounding.ROUND_DOWN)
@@ -741,6 +751,7 @@ def _redeem(
     to the user that is redeeming their vault shares unless it exceeds the given
     `max_loss`.
     """
+    assert not self.paused, "paused"
     assert receiver != empty(address), "ZERO ADDRESS"
     assert shares > 0, "no shares to redeem"
     assert assets > 0, "no assets to withdraw"
@@ -1603,6 +1614,16 @@ def isShutdown() -> bool:
     @return Bool representing the shutdown status
     """
     return self.shutdown
+
+@view
+@external
+def isPaused() -> bool:
+    """
+    @notice Get if the vault is paused.
+    @return Bool representing the paused status.
+    """
+    return self.paused
+
 @view
 @external
 def unlockedShares() -> uint256:
@@ -1761,6 +1782,16 @@ def update_debt(
     return self._update_debt(strategy, target_debt, max_loss)
 
 ## EMERGENCY MANAGEMENT ##
+@external
+def setPaused(paused: bool):
+    """
+    @notice Set the vault's paused status.
+    """
+    self._enforce_role(msg.sender, Roles.EMERGENCY_MANAGER)
+    self.paused = paused
+
+    log UpdatePaused(paused)
+
 @external
 def shutdown_vault():
     """

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -179,7 +179,7 @@ MAX_BPS: constant(uint256) = 10_000
 # Extended for profit locking calculations.
 MAX_BPS_EXTENDED: constant(uint256) = 1_000_000_000_000
 # The version of this vault.
-API_VERSION: constant(String[28]) = "3.0.4"
+API_VERSION: constant(String[28]) = "3.1.0"
 
 # ENUMS #
 # Each permissioned function has its own Role.

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -694,7 +694,7 @@ def _assess_share_of_unrealised_losses(strategy: address, strategy_current_debt:
     numerator: uint256 = assets_needed * strategy_assets
     users_share_of_loss: uint256 = assets_needed - numerator / strategy_current_debt
     # Always round up.
-    if numerator % strategy_current_debt != 0:
+    if numerator % strategy_current_debt != 0 and users_share_of_loss < assets_needed:
         users_share_of_loss += 1
 
     return users_share_of_loss
@@ -822,9 +822,10 @@ def _redeem(
                 assets_needed -= unrealised_losses_share
                 current_total_debt -= unrealised_losses_share
 
-                # If max withdraw is 0 and unrealised loss is still > 0 then the strategy likely
-                # realized a 100% loss and we will need to realize that loss before moving on.
-                if max_withdraw == 0 and unrealised_losses_share > 0:
+                # If assets_to_withdraw is 0 and unrealised loss is still > 0 then the strategy likely
+                # realized a 100% loss or the loss consumed the full withdrawal slice.
+                # Either way, we need to realize that loss before moving on.
+                if assets_to_withdraw == 0 and unrealised_losses_share > 0:
                     # Adjust the strategy debt accordingly.
                     new_debt: uint256 = current_debt - unrealised_losses_share
         

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -39,6 +39,7 @@ interface IVault is IERC4626 {
     event UpdateMinimumTotalIdle(uint256 minimum_total_idle);
     event UpdateProfitMaxUnlockTime(uint256 profit_max_unlock_time);
     event DebtPurchased(address indexed strategy, uint256 amount);
+    event UpdatePaused(bool paused);
     event Shutdown();
 
     struct StrategyParams {
@@ -75,6 +76,8 @@ interface IVault is IERC4626 {
     function future_role_manager() external view returns (address);
 
     function isShutdown() external view returns (bool);
+
+    function isPaused() external view returns (bool);
 
     function nonces(address) external view returns (uint256);
 
@@ -167,6 +170,8 @@ interface IVault is IERC4626 {
         uint256 target_debt,
         uint256 max_loss
     ) external returns (uint256);
+
+    function setPaused(bool paused) external;
 
     function shutdown_vault() external;
 

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -5,7 +5,10 @@ import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 
 interface IVault is IERC4626 {
     // STRATEGY EVENTS
-    event StrategyChanged(address indexed strategy, uint256 change_type);
+    event StrategyChanged(
+        address indexed strategy,
+        uint256 indexed change_type
+    );
     event StrategyReported(
         address indexed strategy,
         uint256 gain,
@@ -22,7 +25,7 @@ interface IVault is IERC4626 {
         uint256 new_debt
     );
     // ROLE UPDATES
-    event RoleSet(address indexed account, uint256 role);
+    event RoleSet(address indexed account, uint256 indexed role);
     event UpdateFutureRoleManager(address indexed future_role_manager);
     event UpdateRoleManager(address indexed role_manager);
 
@@ -51,7 +54,7 @@ interface IVault is IERC4626 {
         uint256 max_debt;
     }
 
-    function FACTORY() external view returns (uint256);
+    function FACTORY() external view returns (address);
 
     function strategies(address) external view returns (StrategyParams memory);
 
@@ -148,6 +151,8 @@ interface IVault is IERC4626 {
     function buy_debt(address strategy, uint256 amount) external;
 
     function add_strategy(address new_strategy) external;
+
+    function add_strategy(address new_strategy, bool add_to_queue) external;
 
     function revoke_strategy(address strategy) external;
 

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -27,6 +27,8 @@ interface IVault is IERC4626 {
     event UpdateRoleManager(address indexed role_manager);
 
     event UpdateAccountant(address indexed accountant);
+    event UpdateDepositHook(address indexed deposit_hook);
+    event UpdateWithdrawHook(address indexed withdraw_hook);
     event UpdateDefaultQueue(address[] new_default_queue);
     event UpdateUseDefaultQueue(bool use_default_queue);
     event UpdatedMaxDebtForStrategy(
@@ -63,9 +65,9 @@ interface IVault is IERC4626 {
 
     function deposit_limit() external view returns (uint256);
 
-    function deposit_limit_module() external view returns (address);
+    function deposit_hook() external view returns (address);
 
-    function withdraw_limit_module() external view returns (address);
+    function withdraw_hook() external view returns (address);
 
     function accountant() external view returns (address);
 
@@ -108,18 +110,14 @@ interface IVault is IERC4626 {
         bool should_override
     ) external;
 
-    function set_deposit_limit_module(
-        address new_deposit_limit_module
-    ) external;
+    function set_deposit_hook(address new_deposit_hook) external;
 
-    function set_deposit_limit_module(
-        address new_deposit_limit_module,
+    function set_deposit_hook(
+        address new_deposit_hook,
         bool should_override
     ) external;
 
-    function set_withdraw_limit_module(
-        address new_withdraw_limit_module
-    ) external;
+    function set_withdraw_hook(address new_withdraw_hook) external;
 
     function set_minimum_total_idle(uint256 minimum_total_idle) external;
 

--- a/contracts/interfaces/IVaultFactory.sol
+++ b/contracts/interfaces/IVaultFactory.sol
@@ -10,16 +10,19 @@ interface IVaultFactory {
         uint16 newProtocolFeeBps
     );
     event UpdateProtocolFeeRecipient(
-        address oldProtocolFeeRecipient,
-        address newProtocolFeeRecipient
+        address indexed oldProtocolFeeRecipient,
+        address indexed newProtocolFeeRecipient
     );
-    event UpdateCustomProtocolFee(address vault, uint16 newCustomProtocolFee);
-    event RemovedCustomProtocolFee(address vault);
+    event UpdateCustomProtocolFee(
+        address indexed vault,
+        uint16 newCustomProtocolFee
+    );
+    event RemovedCustomProtocolFee(address indexed vault);
     event FactoryShutdown();
-    event UpdatePendingGovernance(address newPendingGovernance);
+    event UpdatePendingGovernance(address indexed newPendingGovernance);
     event GovernanceTransferred(
-        address previousGovernance,
-        address newGovernance
+        address indexed previousGovernance,
+        address indexed newGovernance
     );
 
     function shutdown() external view returns (bool);

--- a/contracts/test/mocks/periphery/Accountant.vy
+++ b/contracts/test/mocks/periphery/Accountant.vy
@@ -1,4 +1,5 @@
-# @version 0.3.7
+# @version 0.3.10
+#pragma evm-version paris
 
 from vyper.interfaces import ERC20
 

--- a/contracts/test/mocks/periphery/FaultyAccountant.vy
+++ b/contracts/test/mocks/periphery/FaultyAccountant.vy
@@ -1,4 +1,5 @@
-# @version 0.3.7
+# @version 0.3.10
+#pragma evm-version paris
 
 # FeeManager without any fee threshold
 

--- a/contracts/test/mocks/periphery/FlexibleAccountant.vy
+++ b/contracts/test/mocks/periphery/FlexibleAccountant.vy
@@ -1,4 +1,5 @@
-# @version 0.3.7
+# @version 0.3.10
+#pragma evm-version paris
 
 # FeeManager without any fee threshold
 

--- a/contracts/test/mocks/periphery/HookModule.vy
+++ b/contracts/test/mocks/periphery/HookModule.vy
@@ -1,4 +1,5 @@
-# @version 0.3.7
+# @version 0.3.10
+#pragma evm-version paris
 
 interface IVault:
     def totalAssets() -> uint256: view

--- a/contracts/test/mocks/periphery/HookModule.vy
+++ b/contracts/test/mocks/periphery/HookModule.vy
@@ -13,6 +13,32 @@ default_withdraw_limit: public(uint256)
 
 required_withdraw_strategy: public(address)
 
+last_deposit_sender: public(address)
+
+last_deposit_receiver: public(address)
+
+last_deposit_assets: public(uint256)
+
+last_deposit_shares: public(uint256)
+
+post_deposit_count: public(uint256)
+
+last_withdraw_sender: public(address)
+
+last_withdraw_receiver: public(address)
+
+last_withdraw_owner: public(address)
+
+last_withdraw_assets: public(uint256)
+
+last_withdraw_shares: public(uint256)
+
+post_withdraw_count: public(uint256)
+
+revert_post_deposit: public(bool)
+
+revert_post_withdraw: public(bool)
+
 @external
 def __init__(
     default_deposit_limit: uint256,
@@ -30,8 +56,8 @@ def available_deposit_limit(receiver: address) -> uint256:
         if not self.whitelist[receiver]:
             return 0
 
-    if self.default_deposit_limit == MAX_UINT256:
-        return MAX_UINT256
+    if self.default_deposit_limit == max_value(uint256):
+        return max_value(uint256)
         
     return self.default_deposit_limit - IVault(msg.sender).totalAssets()
 
@@ -45,6 +71,27 @@ def available_withdraw_limit(owner: address, max_loss: uint256, strategies: DynA
             return 0
 
     return self.default_withdraw_limit
+
+@external
+def post_deposit(sender: address, receiver: address, assets: uint256, shares: uint256):
+    assert not self.revert_post_deposit, "post deposit revert"
+
+    self.last_deposit_sender = sender
+    self.last_deposit_receiver = receiver
+    self.last_deposit_assets = assets
+    self.last_deposit_shares = shares
+    self.post_deposit_count += 1
+
+@external
+def post_withdraw(sender: address, receiver: address, owner: address, assets: uint256, shares: uint256):
+    assert not self.revert_post_withdraw, "post withdraw revert"
+
+    self.last_withdraw_sender = sender
+    self.last_withdraw_receiver = receiver
+    self.last_withdraw_owner = owner
+    self.last_withdraw_assets = assets
+    self.last_withdraw_shares = shares
+    self.post_withdraw_count += 1
 
 @external
 def set_whitelist(list: address):
@@ -65,3 +112,11 @@ def set_required_withdraw_strategy(strategy: address):
 @external
 def set_enforce_whitelist(enforce: bool):
     self.enforce_whitelist = enforce
+
+@external
+def set_revert_post_deposit(should_revert: bool):
+    self.revert_post_deposit = should_revert
+
+@external
+def set_revert_post_withdraw(should_revert: bool):
+    self.revert_post_withdraw = should_revert

--- a/contracts/test/mocks/periphery/LimitModule.vy
+++ b/contracts/test/mocks/periphery/LimitModule.vy
@@ -11,6 +11,8 @@ default_deposit_limit: public(uint256)
 
 default_withdraw_limit: public(uint256)
 
+required_withdraw_strategy: public(address)
+
 @external
 def __init__(
     default_deposit_limit: uint256,
@@ -36,6 +38,12 @@ def available_deposit_limit(receiver: address) -> uint256:
 @view
 @external
 def available_withdraw_limit(owner: address, max_loss: uint256, strategies: DynArray[address, 10]) -> uint256:
+    if self.required_withdraw_strategy != empty(address):
+        if len(strategies) == 0:
+            return 0
+        if strategies[0] != self.required_withdraw_strategy:
+            return 0
+
     return self.default_withdraw_limit
 
 @external
@@ -49,6 +57,10 @@ def set_default_deposit_limit(limit: uint256):
 @external
 def set_default_withdraw_limit(limit: uint256):
     self.default_withdraw_limit = limit
+
+@external
+def set_required_withdraw_strategy(strategy: address):
+    self.required_withdraw_strategy = strategy
 
 @external
 def set_enforce_whitelist(enforce: bool):

--- a/foundry.toml
+++ b/foundry.toml
@@ -19,6 +19,9 @@ match_path = "./foundry_tests/tests/*"
 no_match_test = "testFail"
 ffi = true
 
+[profile.default.vyper]
+optimize = "codesize"
+
 [fuzz]
 runs = 250
 max_test_rejects = 1_000_000

--- a/foundry.toml
+++ b/foundry.toml
@@ -16,6 +16,7 @@ fs_permissions = [{ access = "read", path = "./"}]
 
 #match_contract = "VaultERC4626StdTest"
 match_path = "./foundry_tests/tests/*"
+no_match_test = "testFail"
 ffi = true
 
 [fuzz]

--- a/foundry_tests/tests/ERC4626Std.t.sol
+++ b/foundry_tests/tests/ERC4626Std.t.sol
@@ -30,32 +30,50 @@ contract VaultERC4626StdTest is ERC4626Test, Setup {
     }
 
     //Avoid special case for deposits of uint256 max
-    function test_previewDeposit(
-        Init memory init,
-        uint assets
-    ) public override {
+    function test_previewDeposit(Init memory init, uint256 assets) public override {
         if (assets == type(uint256).max) assets -= 1;
         super.test_previewDeposit(init, assets);
     }
 
-    function test_deposit(
-        Init memory init,
-        uint assets,
-        uint allowance
-    ) public override {
+    function test_deposit(Init memory init, uint256 assets, uint256 allowance) public override {
         if (assets == type(uint256).max) assets -= 1;
         super.test_deposit(init, assets, allowance);
     }
 
-    function clamp(
-        Init memory init,
-        uint max
-    ) internal pure returns (Init memory) {
-        for (uint i = 0; i < N; i++) {
+    function test_RevertWhen_withdrawWithoutAllowance(Init memory init, uint256 assets) public {
+        setUpVault(init);
+        address caller = init.user[0];
+        address receiver = init.user[1];
+        address owner = init.user[2];
+        assets = bound(assets, 0, _max_withdraw(owner));
+        vm.assume(caller != owner);
+        vm.assume(assets > 0);
+        _approve(_vault_, owner, caller, 0);
+        vm.prank(caller);
+        vm.expectRevert();
+        IERC4626(_vault_).withdraw(assets, receiver, owner);
+    }
+
+    function test_RevertWhen_redeemWithoutAllowance(Init memory init, uint256 shares) public {
+        setUpVault(init);
+        address caller = init.user[0];
+        address receiver = init.user[1];
+        address owner = init.user[2];
+        shares = bound(shares, 0, _max_redeem(owner));
+        vm.assume(caller != owner);
+        vm.assume(shares > 0);
+        _approve(_vault_, owner, caller, 0);
+        vm.prank(caller);
+        vm.expectRevert();
+        IERC4626(_vault_).redeem(shares, receiver, owner);
+    }
+
+    function clamp(Init memory init, uint256 max) internal pure returns (Init memory) {
+        for (uint256 i = 0; i < N; i++) {
             init.share[i] = init.share[i] % max;
             init.asset[i] = init.asset[i] % max;
         }
-        init.yield = init.yield % int(max);
+        init.yield = init.yield % int256(max);
         return init;
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,19 +1,20 @@
 {
     "name": "yearn-vaults-v3",
     "devDependencies": {
-        "@openzeppelin/contracts": "^4.9.5",
-        "hardhat": "^2.12.2",
-        "prettier": "^2.6.0",
-        "prettier-plugin-solidity": "^1.0.0-beta.19",
-        "pretty-quick": "^3.1.3",
+        "@openzeppelin/contracts": "4.9.6",
+        "hardhat": "2.12.7",
+        "prettier": "2.8.4",
+        "prettier-plugin-solidity": "1.1.2",
+        "pretty-quick": "3.1.3",
         "solc": "0.8.18",
-        "solhint": "^3.3.7",
-        "solhint-plugin-prettier": "^0.0.5",
+        "solhint": "3.4.0",
+        "solhint-plugin-prettier": "0.0.5",
         "solhint-plugin-yearn": "pandadefi/solhint-plugin-yearn"
     },
     "scripts": {
         "format": "prettier --write 'contracts/**/*.(sol|json)' 'foundry_tests/**/*.(sol|json)'",
         "format:check": "prettier --check 'contracts/**/*.*(sol|json)' 'foundry_tests/**/*.(sol|json)'",
         "lint": "solhint 'contracts/**/*.sol' 'foundry_tests/**/*.sol'"
-    }
+    },
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -1,15 +1,11 @@
 {
     "name": "yearn-vaults-v3",
     "devDependencies": {
-        "@openzeppelin/contracts": "4.9.6",
         "hardhat": "2.12.7",
         "prettier": "2.8.4",
         "prettier-plugin-solidity": "1.1.2",
-        "pretty-quick": "3.1.3",
-        "solc": "0.8.18",
         "solhint": "3.4.0",
-        "solhint-plugin-prettier": "0.0.5",
-        "solhint-plugin-yearn": "pandadefi/solhint-plugin-yearn"
+        "solhint-plugin-prettier": "0.0.5"
     },
     "scripts": {
         "format": "prettier --write 'contracts/**/*.(sol|json)' 'foundry_tests/**/*.(sol|json)'",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 black==22.3.0
+click==8.1.8
 eth-ape==0.8.10
 vyper==0.3.7
 eth-typing==3.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 black==22.3.0
 click==8.1.8
 eth-ape==0.8.10
-vyper==0.3.7
+vyper==0.3.10
 eth-typing==3.5.2

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -74,7 +74,9 @@ def deploy_original_and_factory():
 
     print(f"Deployed Vault Factory to {factory_address}")
     print("------------------")
-    print(f"Encoded Constructor to use for verification {factory_constructor.hex()[2:]}")
+    print(
+        f"Encoded Constructor to use for verification {factory_constructor.hex()[2:]}"
+    )
 
 
 def main():

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -18,6 +18,7 @@ def deploy_original_and_factory():
         "0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
     )
 
+    # The deterministic deployer hashes this raw salt before CREATE2.
     salt = HexBytes(
         "0x0000000000000000000000000000000000000000000000000000000000004b62"
     )
@@ -73,7 +74,7 @@ def deploy_original_and_factory():
 
     print(f"Deployed Vault Factory to {factory_address}")
     print("------------------")
-    print(f"Encoded Constructor to use for verifaction {factory_constructor.hex()[2:]}")
+    print(f"Encoded Constructor to use for verification {factory_constructor.hex()[2:]}")
 
 
 def main():

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -1,6 +1,5 @@
 from ape import project, accounts, Contract, chain, networks
 from hexbytes import HexBytes
-import hashlib
 
 
 def deploy_original_and_factory():
@@ -19,26 +18,22 @@ def deploy_original_and_factory():
         "0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed"
     )
 
-    salt_string = ""
+    salt = HexBytes(
+        "0x0000000000000000000000000000000000000000000000000000000000004b62"
+    )
 
-    # Create a SHA-256 hash object
-    hash_object = hashlib.sha256()
-    # Update the hash object with the string data
-    hash_object.update(salt_string.encode("utf-8"))
-    # Get the hexadecimal representation of the hash
-    hex_hash = hash_object.hexdigest()
-    # Convert the hexadecimal hash to an integer
-    salt = 0  # int(hex_hash, 16)
-
-    print(f"Salt we are using {salt}")
     print("Init balance:", deployer.balance / 1e18)
     print("------------------")
-    print(f"Deploying Original...")
+    print(f"Deploying Original with salt {salt}...")
 
     original_deploy_bytecode = vault.contract_type.deployment_bytecode.bytecode
 
     original_tx = deployer_contract.deployCreate2(
-        salt, original_deploy_bytecode, sender=deployer
+        salt,
+        original_deploy_bytecode,
+        sender=deployer,
+        max_fee=chain.provider.gas_price * 2,
+        max_priority_fee=chain.provider.priority_fee,
     )
 
     original_event = list(original_tx.decode_logs(deployer_contract.ContractCreation))
@@ -49,7 +44,7 @@ def deploy_original_and_factory():
     print("------------------")
 
     # deploy factory
-    print(f"Deploying factory...")
+    print(f"Deploying factory with salt {salt}...")
 
     init_gov = "0x6f3cBE2ab3483EC4BA7B672fbdCa0E9B33F88db8"
 
@@ -65,7 +60,11 @@ def deploy_original_and_factory():
     )
 
     factory_tx = deployer_contract.deployCreate2(
-        salt, factory_deploy_bytecode, sender=deployer
+        salt,
+        factory_deploy_bytecode,
+        sender=deployer,
+        max_fee=chain.provider.gas_price * 2,
+        max_priority_fee=chain.provider.priority_fee,
     )
 
     factory_event = list(factory_tx.decode_logs(deployer_contract.ContractCreation))

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -54,7 +54,7 @@ def deploy_original_and_factory():
     init_gov = "0x6f3cBE2ab3483EC4BA7B672fbdCa0E9B33F88db8"
 
     factory_constructor = vault_factory.constructor.encode_input(
-        "Yearn v3.0.4 Vault Factory",
+        "Yearn v3.1.0 Vault Factory",
         original_address,
         init_gov,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -358,16 +358,12 @@ def deploy_faulty_accountant(project, gov):
 
 
 @pytest.fixture(scope="session")
-def deploy_limit_module(project, gov):
-    def deploy_limit_module(
-        deposit_limit=MAX_INT, withdraw_limit=MAX_INT, whitelist=False
-    ):
-        limit_module = gov.deploy(
-            project.LimitModule, deposit_limit, withdraw_limit, whitelist
-        )
-        return limit_module
+def deploy_hook(project, gov):
+    def deploy_hook(deposit_limit=MAX_INT, withdraw_limit=MAX_INT, whitelist=False):
+        hook = gov.deploy(project.HookModule, deposit_limit, withdraw_limit, whitelist)
+        return hook
 
-    yield deploy_limit_module
+    yield deploy_hook
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,11 +106,12 @@ TOKENS_TO_TEST = os.getenv("TOKENS_TO_TEST", default="18").split(",")
 def asset(create_token, mock_real_token, request):
     try:
         token_decimals = int(request.param)
-        # We assume is the number of decimals of the token
-        return create_token("asset", decimals=token_decimals)
-    except:
+    except ValueError:
         # We assume is the name of the real token to test with
         return mock_real_token(name=request.param)
+
+    # We assume is the number of decimals of the token
+    return create_token("asset", decimals=token_decimals)
 
 
 # use this for token mock
@@ -190,7 +191,8 @@ def create_vault(project, gov, vault_factory):
             sender=gov,
         )
         event = list(tx.decode_logs(vault_factory.NewVault))
-        vault = project.VaultV3.at(event[0].vault_address)
+        vault = project.VaultV3.at(event[0].vault_address, txn_hash=tx.txn_hash)
+        chain.contracts.cache_deployment(vault)
 
         vault.set_role(
             gov.address,

--- a/tests/unit/vault/test_emergency_shutdown.py
+++ b/tests/unit/vault/test_emergency_shutdown.py
@@ -53,8 +53,8 @@ def test_shutdown__increase_deposit_limit__reverts(
     assert vault.maxDeposit(gov) == 0
 
 
-def test_shutdown__set_deposit_limit_module__reverts(
-    vault, gov, asset, mint_and_deposit_into_vault, deploy_limit_module
+def test_shutdown__set_deposit_hook__reverts(
+    vault, gov, asset, mint_and_deposit_into_vault, deploy_hook
 ):
     mint_and_deposit_into_vault(vault, gov)
     vault.shutdown_vault(sender=gov)
@@ -65,34 +65,34 @@ def test_shutdown__set_deposit_limit_module__reverts(
 
     assert ROLES.DEPOSIT_LIMIT_MANAGER in ROLES(vault.roles(gov))
 
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
 
     with ape.reverts():
-        vault.set_deposit_limit_module(limit_module, sender=gov)
+        vault.set_deposit_hook(hook, sender=gov)
 
     assert vault.maxDeposit(gov) == 0
 
 
-def test_shutdown__deposit_limit_module_is_removed(
-    create_vault, gov, asset, mint_and_deposit_into_vault, deploy_limit_module
+def test_shutdown__deposit_hook_is_removed(
+    create_vault, gov, asset, mint_and_deposit_into_vault, deploy_hook
 ):
     vault = create_vault(asset)
 
     mint_and_deposit_into_vault(vault, gov)
 
-    limit_module = deploy_limit_module()
-    vault.set_deposit_limit_module(limit_module, sender=gov)
+    hook = deploy_hook()
+    vault.set_deposit_hook(hook, sender=gov)
 
     assert vault.maxDeposit(gov) > 0
 
     tx = vault.shutdown_vault(sender=gov)
 
-    event = list(tx.decode_logs(vault.UpdateDepositLimitModule))
+    event = list(tx.decode_logs(vault.UpdateDepositHook))
 
     assert len(event) == 1
-    assert event[0].deposit_limit_module == ZERO_ADDRESS
+    assert event[0].deposit_hook == ZERO_ADDRESS
 
-    assert vault.deposit_limit_module() == ZERO_ADDRESS
+    assert vault.deposit_hook() == ZERO_ADDRESS
     assert vault.maxDeposit(gov) == 0
 
 

--- a/tests/unit/vault/test_erc4626.py
+++ b/tests/unit/vault/test_erc4626.py
@@ -960,3 +960,89 @@ def test_redeem__with_withdraw_limit_module(
     assert vault.balanceOf(fish.address) == 0
     assert asset.balanceOf(vault.address) == 0
     assert asset.balanceOf(fish.address) == assets
+
+
+def test_redeem__with_withdraw_limit_module_uses_default_queue(
+    asset,
+    fish,
+    fish_amount,
+    gov,
+    create_vault,
+    create_strategy,
+    add_debt_to_strategy,
+    add_strategy_to_vault,
+    deploy_limit_module,
+    user_deposit,
+):
+    vault = create_vault(asset)
+    limit_module = deploy_limit_module()
+    strategy = create_strategy(vault)
+    assets = fish_amount
+
+    user_deposit(fish, vault, asset, assets)
+    add_strategy_to_vault(gov, strategy, vault)
+    add_debt_to_strategy(gov, strategy, vault, assets)
+
+    vault.set_withdraw_limit_module(limit_module, sender=gov)
+    limit_module.set_required_withdraw_strategy(strategy.address, sender=gov)
+
+    assert vault.maxRedeem(fish.address) == assets
+
+    tx = vault.redeem(assets, fish.address, fish.address, sender=fish)
+
+    event = list(tx.decode_logs(vault.Withdraw))[-1]
+
+    assert event.assets == assets
+    assert event.shares == assets
+    assert event.owner == fish
+    assert event.receiver == fish
+    assert vault.balanceOf(fish.address) == 0
+    assert asset.balanceOf(fish.address) == assets
+
+
+def test_withdraw__with_withdraw_limit_module_uses_forced_default_queue(
+    asset,
+    fish,
+    fish_amount,
+    gov,
+    create_vault,
+    create_strategy,
+    add_debt_to_strategy,
+    add_strategy_to_vault,
+    deploy_limit_module,
+    user_deposit,
+):
+    vault = create_vault(asset)
+    limit_module = deploy_limit_module()
+    default_strategy = create_strategy(vault)
+    custom_strategy = create_strategy(vault)
+    assets = fish_amount
+
+    user_deposit(fish, vault, asset, assets)
+    add_strategy_to_vault(gov, default_strategy, vault)
+    add_strategy_to_vault(gov, custom_strategy, vault)
+    add_debt_to_strategy(gov, default_strategy, vault, assets)
+
+    vault.set_withdraw_limit_module(limit_module, sender=gov)
+    limit_module.set_required_withdraw_strategy(default_strategy.address, sender=gov)
+    vault.set_use_default_queue(True, sender=gov)
+
+    assert vault.maxWithdraw(fish.address, 0, [custom_strategy]) == assets
+
+    tx = vault.withdraw(
+        assets,
+        fish.address,
+        fish.address,
+        0,
+        [custom_strategy],
+        sender=fish,
+    )
+
+    event = list(tx.decode_logs(vault.Withdraw))[-1]
+
+    assert event.assets == assets
+    assert event.shares == assets
+    assert event.owner == fish
+    assert event.receiver == fish
+    assert vault.balanceOf(fish.address) == 0
+    assert asset.balanceOf(fish.address) == assets

--- a/tests/unit/vault/test_erc4626.py
+++ b/tests/unit/vault/test_erc4626.py
@@ -223,6 +223,40 @@ def test_max_withdraw__with_lossy_strategy(
     assert vault.maxWithdraw(fish.address) == total_idle
 
 
+def test_max_withdraw__tiny_unrealised_loss_does_not_underflow(
+    asset,
+    fish,
+    bunny,
+    gov,
+    create_vault,
+    create_lossy_strategy,
+    add_debt_to_strategy,
+    add_strategy_to_vault,
+    user_deposit,
+    airdrop_asset,
+):
+    vault = create_vault(asset)
+    lossy_strategy = create_lossy_strategy(vault)
+
+    airdrop_asset(gov, asset, bunny, 1)
+    user_deposit(fish, vault, asset, 1)
+    user_deposit(bunny, vault, asset, 1)
+
+    vault.set_role(
+        gov.address,
+        ROLES.ADD_STRATEGY_MANAGER | ROLES.DEBT_MANAGER | ROLES.MAX_DEBT_MANAGER,
+        sender=gov,
+    )
+    add_strategy_to_vault(gov, lossy_strategy, vault)
+    add_debt_to_strategy(gov, lossy_strategy, vault, 2)
+
+    lossy_strategy.setLoss(gov.address, 1, sender=gov)
+
+    assert vault.maxWithdraw(fish.address, 10_000, [lossy_strategy.address]) == 1
+    assert vault.maxRedeem(fish.address, 10_000, [lossy_strategy.address]) == 1
+    assert vault.maxWithdraw(fish.address, 0, [lossy_strategy.address]) == 0
+
+
 # Tests if the first strategy has no losses but the second does
 # maxWithdraw will account for the first and not the second.
 def test_max_withdraw__with_liquid_and_lossy_strategy(

--- a/tests/unit/vault/test_erc4626.py
+++ b/tests/unit/vault/test_erc4626.py
@@ -648,27 +648,27 @@ def test_max_redeem__with_use_default_queue(
     assert vault.maxRedeem(fish.address, 22, [vault]) == assets
 
 
-# With limit modules
+# With hooks
 
 
-def test_max_deposit__with_deposit_limit_module(
-    asset, fish, fish_amount, gov, create_vault, deploy_limit_module, user_deposit
+def test_max_deposit__with_deposit_hook(
+    asset, fish, fish_amount, gov, create_vault, deploy_hook, user_deposit
 ):
     vault = create_vault(asset, deposit_limit=0)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
     assets = fish_amount
 
     assert vault.deposit_limit() == 0
     assert vault.maxDeposit(fish.address) == 0
 
     vault.set_deposit_limit(MAX_INT, sender=gov)
-    vault.set_deposit_limit_module(limit_module, sender=gov)
+    vault.set_deposit_hook(hook, sender=gov)
 
-    assert vault.deposit_limit_module() == limit_module.address
+    assert vault.deposit_hook() == hook.address
     assert vault.maxDeposit(fish.address) == MAX_INT
 
     new_limit = assets * 2
-    limit_module.set_default_deposit_limit(new_limit, sender=gov)
+    hook.set_default_deposit_limit(new_limit, sender=gov)
 
     user_deposit(fish, vault, asset, assets)
 
@@ -679,34 +679,34 @@ def test_max_deposit__with_deposit_limit_module(
     assert vault.maxDeposit(vault.address) == 0
 
     # If not on a whitelist it reverts.
-    limit_module.set_enforce_whitelist(True, sender=gov)
+    hook.set_enforce_whitelist(True, sender=gov)
 
     assert vault.maxDeposit(fish.address) == 0
 
     # If whitelisted it now works
-    limit_module.set_whitelist(fish.address, sender=gov)
+    hook.set_whitelist(fish.address, sender=gov)
 
     assert vault.maxDeposit(fish.address) == new_limit - assets
 
 
-def test_max_mint__with_deposit_limit_module(
-    asset, fish, fish_amount, gov, create_vault, deploy_limit_module, user_deposit
+def test_max_mint__with_deposit_hook(
+    asset, fish, fish_amount, gov, create_vault, deploy_hook, user_deposit
 ):
     vault = create_vault(asset, deposit_limit=0)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
     assets = fish_amount
 
     assert vault.deposit_limit() == 0
     assert vault.maxMint(fish.address) == 0
 
     vault.set_deposit_limit(MAX_INT, sender=gov)
-    vault.set_deposit_limit_module(limit_module, sender=gov)
+    vault.set_deposit_hook(hook, sender=gov)
 
-    assert vault.deposit_limit_module() == limit_module.address
+    assert vault.deposit_hook() == hook.address
     assert vault.maxDeposit(fish.address) == MAX_INT
 
     new_limit = assets * 2
-    limit_module.set_default_deposit_limit(new_limit, sender=gov)
+    hook.set_default_deposit_limit(new_limit, sender=gov)
 
     user_deposit(fish, vault, asset, assets)
 
@@ -717,47 +717,47 @@ def test_max_mint__with_deposit_limit_module(
     assert vault.maxMint(vault.address) == 0
 
     # If not on a whitelist it reverts.
-    limit_module.set_enforce_whitelist(True, sender=gov)
+    hook.set_enforce_whitelist(True, sender=gov)
 
     assert vault.maxMint(fish.address) == 0
 
     # If whitelisted it now works
-    limit_module.set_whitelist(fish.address, sender=gov)
+    hook.set_whitelist(fish.address, sender=gov)
 
     assert vault.maxMint(fish.address) == new_limit - assets
 
 
-def test_max_withdraw__with_withdraw_limit_module(
+def test_max_withdraw__with_withdraw_hook(
     asset,
     fish,
     bunny,
     fish_amount,
     gov,
     create_vault,
-    deploy_limit_module,
+    deploy_hook,
     user_deposit,
 ):
     vault = create_vault(asset)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
     assets = fish_amount // 2
 
     assert vault.maxWithdraw(fish.address) == 0
 
-    vault.set_withdraw_limit_module(limit_module, sender=gov)
+    vault.set_withdraw_hook(hook, sender=gov)
 
-    assert vault.withdraw_limit_module() == limit_module.address
+    assert vault.withdraw_hook() == hook.address
     # Max withdraw should still be 0
     assert vault.maxWithdraw(fish.address) == 0
 
     user_deposit(fish, vault, asset, assets)
 
     # Max should be uint max but amount is brought down based on balances.
-    assert limit_module.default_withdraw_limit() == MAX_INT
+    assert hook.default_withdraw_limit() == MAX_INT
     assert vault.maxWithdraw(fish.address) == assets
     assert vault.maxWithdraw(bunny.address) == 0
 
     new_limit = assets * 2
-    limit_module.set_default_withdraw_limit(new_limit, sender=gov)
+    hook.set_default_withdraw_limit(new_limit, sender=gov)
 
     # Doesn't change
     assert vault.maxWithdraw(fish.address) == assets
@@ -766,44 +766,44 @@ def test_max_withdraw__with_withdraw_limit_module(
 
     # Set limit below the balance
     new_limit = assets // 2
-    limit_module.set_default_withdraw_limit(new_limit, sender=gov)
+    hook.set_default_withdraw_limit(new_limit, sender=gov)
 
     assert vault.maxWithdraw(fish.address) == new_limit
     assert vault.maxWithdraw(fish.address, 23, [vault]) == new_limit
     assert vault.maxWithdraw(bunny.address) == 0
 
 
-def test_max_redeem__with_withdraw_limit_module(
+def test_max_redeem__with_withdraw_hook(
     asset,
     fish,
     bunny,
     fish_amount,
     gov,
     create_vault,
-    deploy_limit_module,
+    deploy_hook,
     user_deposit,
 ):
     vault = create_vault(asset)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
     assets = fish_amount // 2
 
     assert vault.maxRedeem(fish.address) == 0
 
-    vault.set_withdraw_limit_module(limit_module, sender=gov)
+    vault.set_withdraw_hook(hook, sender=gov)
 
-    assert vault.withdraw_limit_module() == limit_module.address
+    assert vault.withdraw_hook() == hook.address
     # Max withdraw should still be 0
     assert vault.maxRedeem(fish.address) == 0
 
     user_deposit(fish, vault, asset, assets)
 
     # Max should be uint max but amount is brought down based on balances.
-    assert limit_module.default_withdraw_limit() == MAX_INT
+    assert hook.default_withdraw_limit() == MAX_INT
     assert vault.maxRedeem(fish.address) == assets
     assert vault.maxRedeem(bunny.address) == 0
 
     new_limit = assets * 2
-    limit_module.set_default_withdraw_limit(new_limit, sender=gov)
+    hook.set_default_withdraw_limit(new_limit, sender=gov)
 
     # Doesn't change
     assert vault.maxRedeem(fish.address) == assets
@@ -812,7 +812,7 @@ def test_max_redeem__with_withdraw_limit_module(
 
     # Set limit below the balance
     new_limit = assets // 2
-    limit_module.set_default_withdraw_limit(new_limit, sender=gov)
+    hook.set_default_withdraw_limit(new_limit, sender=gov)
 
     assert vault.maxRedeem(fish.address) == new_limit
     assert vault.maxRedeem(fish.address, 23, [vault]) == new_limit
@@ -820,7 +820,7 @@ def test_max_redeem__with_withdraw_limit_module(
 
 
 def test_deposit__with_max_uint(
-    asset, fish, fish_amount, gov, create_vault, deploy_limit_module, user_deposit
+    asset, fish, fish_amount, gov, create_vault, deploy_hook, user_deposit
 ):
     vault = create_vault(asset)
     assets = fish_amount
@@ -842,20 +842,20 @@ def test_deposit__with_max_uint(
     assert asset.balanceOf(vault.address) == assets
 
 
-def test_deposit__with_deposit_limit_module(
-    asset, fish, fish_amount, gov, create_vault, deploy_limit_module, user_deposit
+def test_deposit__with_deposit_hook(
+    asset, fish, fish_amount, gov, create_vault, deploy_hook, user_deposit
 ):
     vault = create_vault(asset, deposit_limit=0)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
     assets = fish_amount
 
     asset.approve(vault.address, assets, sender=fish)
 
     vault.set_deposit_limit(MAX_INT, sender=gov)
-    vault.set_deposit_limit_module(limit_module, sender=gov)
+    vault.set_deposit_hook(hook, sender=gov)
 
     # If not on a whitelist it reverts.
-    limit_module.set_enforce_whitelist(True, sender=gov)
+    hook.set_enforce_whitelist(True, sender=gov)
 
     assert vault.maxDeposit(fish.address) == 0
 
@@ -863,7 +863,7 @@ def test_deposit__with_deposit_limit_module(
         vault.deposit(assets, fish.address, sender=fish)
 
     # If whitelisted it now works
-    limit_module.set_whitelist(fish.address, sender=gov)
+    hook.set_whitelist(fish.address, sender=gov)
     assert vault.maxDeposit(fish.address) == MAX_INT
 
     # Should go through now
@@ -877,22 +877,27 @@ def test_deposit__with_deposit_limit_module(
     assert event.sender == fish
     assert vault.balanceOf(fish.address) == assets
     assert asset.balanceOf(vault.address) == assets
+    assert hook.post_deposit_count() == 1
+    assert hook.last_deposit_sender() == fish.address
+    assert hook.last_deposit_receiver() == fish.address
+    assert hook.last_deposit_assets() == assets
+    assert hook.last_deposit_shares() == assets
 
 
-def test_mint__with_deposit_limit_module(
-    asset, fish, fish_amount, gov, create_vault, deploy_limit_module, user_deposit
+def test_mint__with_deposit_hook(
+    asset, fish, fish_amount, gov, create_vault, deploy_hook, user_deposit
 ):
     vault = create_vault(asset, deposit_limit=0)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
     assets = fish_amount
 
     asset.approve(vault.address, assets, sender=fish)
 
     vault.set_deposit_limit(MAX_INT, sender=gov)
-    vault.set_deposit_limit_module(limit_module, sender=gov)
+    vault.set_deposit_hook(hook, sender=gov)
 
     # If not on a whitelist it reverts.
-    limit_module.set_enforce_whitelist(True, sender=gov)
+    hook.set_enforce_whitelist(True, sender=gov)
 
     assert vault.maxMint(fish.address) == 0
 
@@ -900,7 +905,7 @@ def test_mint__with_deposit_limit_module(
         vault.mint(assets, fish.address, sender=fish)
 
     # If whitelisted it now works
-    limit_module.set_whitelist(fish.address, sender=gov)
+    hook.set_whitelist(fish.address, sender=gov)
     assert vault.maxMint(fish.address) == MAX_INT
 
     # Should go through now
@@ -914,23 +919,51 @@ def test_mint__with_deposit_limit_module(
     assert event.sender == fish
     assert vault.balanceOf(fish.address) == assets
     assert asset.balanceOf(vault.address) == assets
+    assert hook.post_deposit_count() == 1
+    assert hook.last_deposit_sender() == fish.address
+    assert hook.last_deposit_receiver() == fish.address
+    assert hook.last_deposit_assets() == assets
+    assert hook.last_deposit_shares() == assets
 
 
-def test_withdraw__with_withdraw_limit_module(
-    asset, fish, fish_amount, gov, create_vault, deploy_limit_module, user_deposit
+def test_deposit__post_deposit_hook_reverts(
+    asset, fish, fish_amount, gov, create_vault, deploy_hook
 ):
     vault = create_vault(asset)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
+    assets = fish_amount
+
+    asset.approve(vault.address, assets, sender=fish)
+    vault.set_deposit_hook(hook, sender=gov)
+    hook.set_revert_post_deposit(True, sender=gov)
+
+    fish_balance_before = asset.balanceOf(fish)
+    vault_balance_before = asset.balanceOf(vault)
+
+    with ape.reverts("post deposit revert"):
+        vault.deposit(assets, fish.address, sender=fish)
+
+    assert hook.post_deposit_count() == 0
+    assert vault.balanceOf(fish.address) == 0
+    assert asset.balanceOf(fish) == fish_balance_before
+    assert asset.balanceOf(vault) == vault_balance_before
+
+
+def test_withdraw__with_withdraw_hook(
+    asset, fish, fish_amount, gov, create_vault, deploy_hook, user_deposit
+):
+    vault = create_vault(asset)
+    hook = deploy_hook()
     assets = fish_amount
 
     user_deposit(fish, vault, asset, assets)
 
-    vault.set_withdraw_limit_module(limit_module, sender=gov)
+    vault.set_withdraw_hook(hook, sender=gov)
 
     assert vault.maxWithdraw(fish.address) == assets
 
     new_limit = 0
-    limit_module.set_default_withdraw_limit(new_limit, sender=gov)
+    hook.set_default_withdraw_limit(new_limit, sender=gov)
 
     assert vault.maxWithdraw(fish.address) == 0
 
@@ -938,7 +971,7 @@ def test_withdraw__with_withdraw_limit_module(
         vault.withdraw(assets, fish.address, fish.address, sender=fish)
 
     new_limit = assets
-    limit_module.set_default_withdraw_limit(new_limit, sender=gov)
+    hook.set_default_withdraw_limit(new_limit, sender=gov)
 
     assert vault.maxWithdraw(fish.address) == assets
 
@@ -954,23 +987,52 @@ def test_withdraw__with_withdraw_limit_module(
     assert vault.balanceOf(fish.address) == 0
     assert asset.balanceOf(vault.address) == 0
     assert asset.balanceOf(fish.address) == assets
+    assert hook.post_withdraw_count() == 1
+    assert hook.last_withdraw_sender() == fish.address
+    assert hook.last_withdraw_receiver() == fish.address
+    assert hook.last_withdraw_owner() == fish.address
+    assert hook.last_withdraw_assets() == assets
+    assert hook.last_withdraw_shares() == assets
 
 
-def test_redeem__with_withdraw_limit_module(
-    asset, fish, fish_amount, gov, create_vault, deploy_limit_module, user_deposit
+def test_withdraw__post_withdraw_hook_reverts(
+    asset, fish, fish_amount, gov, create_vault, deploy_hook, user_deposit
 ):
     vault = create_vault(asset)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
+    assets = fish_amount
+
+    user_deposit(fish, vault, asset, assets)
+    vault.set_withdraw_hook(hook, sender=gov)
+    hook.set_revert_post_withdraw(True, sender=gov)
+
+    fish_balance_before = asset.balanceOf(fish)
+    vault_balance_before = asset.balanceOf(vault)
+
+    with ape.reverts("post withdraw revert"):
+        vault.withdraw(assets, fish.address, fish.address, sender=fish)
+
+    assert hook.post_withdraw_count() == 0
+    assert vault.balanceOf(fish.address) == assets
+    assert asset.balanceOf(fish) == fish_balance_before
+    assert asset.balanceOf(vault) == vault_balance_before
+
+
+def test_redeem__with_withdraw_hook(
+    asset, fish, fish_amount, gov, create_vault, deploy_hook, user_deposit
+):
+    vault = create_vault(asset)
+    hook = deploy_hook()
     assets = fish_amount
 
     user_deposit(fish, vault, asset, assets)
 
-    vault.set_withdraw_limit_module(limit_module, sender=gov)
+    vault.set_withdraw_hook(hook, sender=gov)
 
     assert vault.maxRedeem(fish.address) == assets
 
     new_limit = 0
-    limit_module.set_default_withdraw_limit(new_limit, sender=gov)
+    hook.set_default_withdraw_limit(new_limit, sender=gov)
 
     assert vault.maxRedeem(fish.address) == 0
 
@@ -978,7 +1040,7 @@ def test_redeem__with_withdraw_limit_module(
         vault.redeem(assets, fish.address, fish.address, sender=fish)
 
     new_limit = assets
-    limit_module.set_default_withdraw_limit(new_limit, sender=gov)
+    hook.set_default_withdraw_limit(new_limit, sender=gov)
 
     assert vault.maxRedeem(fish.address) == assets
 
@@ -994,9 +1056,15 @@ def test_redeem__with_withdraw_limit_module(
     assert vault.balanceOf(fish.address) == 0
     assert asset.balanceOf(vault.address) == 0
     assert asset.balanceOf(fish.address) == assets
+    assert hook.post_withdraw_count() == 1
+    assert hook.last_withdraw_sender() == fish.address
+    assert hook.last_withdraw_receiver() == fish.address
+    assert hook.last_withdraw_owner() == fish.address
+    assert hook.last_withdraw_assets() == assets
+    assert hook.last_withdraw_shares() == assets
 
 
-def test_redeem__with_withdraw_limit_module_uses_default_queue(
+def test_redeem__with_withdraw_hook_uses_default_queue(
     asset,
     fish,
     fish_amount,
@@ -1005,11 +1073,11 @@ def test_redeem__with_withdraw_limit_module_uses_default_queue(
     create_strategy,
     add_debt_to_strategy,
     add_strategy_to_vault,
-    deploy_limit_module,
+    deploy_hook,
     user_deposit,
 ):
     vault = create_vault(asset)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
     strategy = create_strategy(vault)
     assets = fish_amount
 
@@ -1017,8 +1085,8 @@ def test_redeem__with_withdraw_limit_module_uses_default_queue(
     add_strategy_to_vault(gov, strategy, vault)
     add_debt_to_strategy(gov, strategy, vault, assets)
 
-    vault.set_withdraw_limit_module(limit_module, sender=gov)
-    limit_module.set_required_withdraw_strategy(strategy.address, sender=gov)
+    vault.set_withdraw_hook(hook, sender=gov)
+    hook.set_required_withdraw_strategy(strategy.address, sender=gov)
 
     assert vault.maxRedeem(fish.address) == assets
 
@@ -1034,7 +1102,7 @@ def test_redeem__with_withdraw_limit_module_uses_default_queue(
     assert asset.balanceOf(fish.address) == assets
 
 
-def test_withdraw__with_withdraw_limit_module_uses_forced_default_queue(
+def test_withdraw__with_withdraw_hook_uses_forced_default_queue(
     asset,
     fish,
     fish_amount,
@@ -1043,11 +1111,11 @@ def test_withdraw__with_withdraw_limit_module_uses_forced_default_queue(
     create_strategy,
     add_debt_to_strategy,
     add_strategy_to_vault,
-    deploy_limit_module,
+    deploy_hook,
     user_deposit,
 ):
     vault = create_vault(asset)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
     default_strategy = create_strategy(vault)
     custom_strategy = create_strategy(vault)
     assets = fish_amount
@@ -1057,8 +1125,8 @@ def test_withdraw__with_withdraw_limit_module_uses_forced_default_queue(
     add_strategy_to_vault(gov, custom_strategy, vault)
     add_debt_to_strategy(gov, default_strategy, vault, assets)
 
-    vault.set_withdraw_limit_module(limit_module, sender=gov)
-    limit_module.set_required_withdraw_strategy(default_strategy.address, sender=gov)
+    vault.set_withdraw_hook(hook, sender=gov)
+    hook.set_required_withdraw_strategy(default_strategy.address, sender=gov)
     vault.set_use_default_queue(True, sender=gov)
 
     assert vault.maxWithdraw(fish.address, 0, [custom_strategy]) == assets

--- a/tests/unit/vault/test_pause.py
+++ b/tests/unit/vault/test_pause.py
@@ -1,0 +1,114 @@
+import ape
+from utils.constants import MAX_INT, ROLES
+
+
+def test_setPaused__no_emergency_manager__reverts(asset, create_vault, bunny):
+    vault = create_vault(asset)
+
+    with ape.reverts("not allowed"):
+        vault.setPaused(True, sender=bunny)
+
+
+def test_setPaused__emergency_manager(asset, create_vault, gov, bunny):
+    vault = create_vault(asset)
+    vault.set_role(bunny.address, ROLES.EMERGENCY_MANAGER, sender=gov)
+
+    assert vault.isPaused() == False
+
+    tx = vault.setPaused(True, sender=bunny)
+    event = list(tx.decode_logs(vault.UpdatePaused))
+
+    assert len(event) == 1
+    assert event[0].paused == True
+    assert vault.isPaused() == True
+
+    tx = vault.setPaused(False, sender=bunny)
+    event = list(tx.decode_logs(vault.UpdatePaused))
+
+    assert len(event) == 1
+    assert event[0].paused == False
+    assert vault.isPaused() == False
+
+
+def test_paused_blocks_erc4626_user_flows(
+    asset, create_vault, fish, fish_amount, gov, mint_and_deposit_into_vault
+):
+    vault = create_vault(asset)
+    amount = fish_amount
+
+    mint_and_deposit_into_vault(vault, fish, amount)
+    vault.setPaused(True, sender=gov)
+
+    assert vault.maxDeposit(fish.address) == 0
+    assert vault.maxMint(fish.address) == 0
+    assert vault.maxWithdraw(fish.address) == 0
+    assert vault.maxRedeem(fish.address) == 0
+
+    with ape.reverts("exceed deposit limit"):
+        vault.deposit(amount, fish.address, sender=fish)
+
+    with ape.reverts("exceed deposit limit"):
+        vault.mint(amount, fish.address, sender=fish)
+
+    with ape.reverts("paused"):
+        vault.withdraw(amount, fish.address, fish.address, sender=fish)
+
+    with ape.reverts("paused"):
+        vault.redeem(amount, fish.address, fish.address, sender=fish)
+
+
+def test_unpause_restores_erc4626_user_flows(
+    asset, create_vault, fish, fish_amount, gov
+):
+    vault = create_vault(asset)
+    amount = fish_amount
+
+    vault.setPaused(True, sender=gov)
+    vault.setPaused(False, sender=gov)
+
+    asset.mint(fish.address, amount, sender=gov)
+    asset.approve(vault.address, amount, sender=fish)
+    vault.deposit(amount, fish.address, sender=fish)
+
+    assert vault.maxWithdraw(fish.address) == amount
+
+    vault.withdraw(amount, fish.address, fish.address, sender=fish)
+    assert vault.balanceOf(fish.address) == 0
+
+
+def test_paused_keeps_erc20_share_flows_live(
+    asset, create_vault, fish, fish_amount, bunny, gov, mint_and_deposit_into_vault
+):
+    vault = create_vault(asset)
+    amount = fish_amount
+    half = amount // 2
+
+    mint_and_deposit_into_vault(vault, fish, amount)
+    vault.setPaused(True, sender=gov)
+
+    vault.transfer(bunny.address, half, sender=fish)
+    vault.approve(bunny.address, half, sender=fish)
+    vault.transferFrom(fish.address, bunny.address, half, sender=bunny)
+
+    assert vault.balanceOf(fish.address) == 0
+    assert vault.balanceOf(bunny.address) == amount
+
+
+def test_paused_keeps_debt_management_live(
+    asset, create_vault, create_strategy, gov, mint_and_deposit_into_vault
+):
+    vault = create_vault(asset)
+    strategy = create_strategy(vault)
+    amount = 10**18
+
+    vault.add_strategy(strategy.address, sender=gov)
+    strategy.setMaxDebt(MAX_INT, sender=gov)
+    mint_and_deposit_into_vault(vault, gov, amount)
+
+    vault.setPaused(True, sender=gov)
+
+    vault.update_max_debt_for_strategy(strategy.address, amount, sender=gov)
+    vault.update_debt(strategy.address, amount, sender=gov)
+
+    assert vault.strategies(strategy.address).current_debt == amount
+    assert asset.balanceOf(strategy.address) == amount

--- a/tests/unit/vault/test_role_base_access.py
+++ b/tests/unit/vault/test_role_base_access.py
@@ -149,7 +149,7 @@ def test_set_deposit_limit__deposit_limit_manager(gov, vault, bunny):
     assert vault.deposit_limit() == deposit_limit
 
 
-def test_set_deposit_limit_with_limit_module__reverts(gov, vault, bunny):
+def test_set_deposit_limit_with_hook__reverts(gov, vault, bunny):
     # We temporarily give bunny the role
     tx = vault.set_role(bunny.address, ROLES.DEPOSIT_LIMIT_MANAGER, sender=gov)
 
@@ -160,13 +160,13 @@ def test_set_deposit_limit_with_limit_module__reverts(gov, vault, bunny):
 
     deposit_limit = 1
 
-    vault.set_deposit_limit_module(bunny, sender=gov)
+    vault.set_deposit_hook(bunny, sender=gov)
 
-    with ape.reverts("using module"):
+    with ape.reverts("using hook"):
         vault.set_deposit_limit(deposit_limit, sender=bunny)
 
 
-def test_set_deposit_limit_with_limit_module__override(gov, vault, bunny):
+def test_set_deposit_limit_with_hook__override(gov, vault, bunny):
     # We temporarily give bunny the role
     tx = vault.set_role(bunny.address, ROLES.DEPOSIT_LIMIT_MANAGER, sender=gov)
 
@@ -176,24 +176,24 @@ def test_set_deposit_limit_with_limit_module__override(gov, vault, bunny):
     assert event[0].role == ROLES.DEPOSIT_LIMIT_MANAGER
 
     deposit_limit = 1
-    deposit_limit_module = bunny
+    deposit_hook = bunny
 
-    vault.set_deposit_limit_module(deposit_limit_module, sender=gov)
+    vault.set_deposit_hook(deposit_hook, sender=gov)
 
-    assert vault.deposit_limit_module() == deposit_limit_module
+    assert vault.deposit_hook() == deposit_hook
 
-    with ape.reverts("using module"):
+    with ape.reverts("using hook"):
         vault.set_deposit_limit(deposit_limit, sender=bunny)
 
     tx = vault.set_deposit_limit(deposit_limit, True, sender=bunny)
 
     assert vault.deposit_limit() == deposit_limit
-    assert vault.deposit_limit_module() == ZERO_ADDRESS
+    assert vault.deposit_hook() == ZERO_ADDRESS
 
-    event = list(tx.decode_logs(vault.UpdateDepositLimitModule))
+    event = list(tx.decode_logs(vault.UpdateDepositHook))
 
     assert len(event) == 1
-    assert event[0].deposit_limit_module == ZERO_ADDRESS
+    assert event[0].deposit_hook == ZERO_ADDRESS
 
     event = list(tx.decode_logs(vault.UpdateDepositLimit))
 
@@ -201,13 +201,13 @@ def test_set_deposit_limit_with_limit_module__override(gov, vault, bunny):
     assert event[0].deposit_limit == deposit_limit
 
 
-def test_set_deposit_limit_module__no_deposit_limit_manager__reverts(bunny, vault):
-    deposit_limit_module = bunny
+def test_set_deposit_hook__no_deposit_limit_manager__reverts(bunny, vault):
+    deposit_hook = bunny
     with ape.reverts("not allowed"):
-        vault.set_deposit_limit_module(deposit_limit_module, sender=bunny)
+        vault.set_deposit_hook(deposit_hook, sender=bunny)
 
 
-def test_set_deposit_limit_module__deposit_limit_manager(gov, vault, bunny):
+def test_set_deposit_hook__deposit_limit_manager(gov, vault, bunny):
     # We temporarily give bunny the role
     tx = vault.set_role(bunny.address, ROLES.DEPOSIT_LIMIT_MANAGER, sender=gov)
 
@@ -216,19 +216,19 @@ def test_set_deposit_limit_module__deposit_limit_manager(gov, vault, bunny):
     assert event[0].account == bunny.address
     assert event[0].role == ROLES.DEPOSIT_LIMIT_MANAGER
 
-    deposit_limit_module = bunny
-    assert vault.deposit_limit_module() == ZERO_ADDRESS
-    tx = vault.set_deposit_limit_module(deposit_limit_module, sender=bunny)
+    deposit_hook = bunny
+    assert vault.deposit_hook() == ZERO_ADDRESS
+    tx = vault.set_deposit_hook(deposit_hook, sender=bunny)
 
-    assert vault.deposit_limit_module() == deposit_limit_module
+    assert vault.deposit_hook() == deposit_hook
 
-    event = list(tx.decode_logs(vault.UpdateDepositLimitModule))
+    event = list(tx.decode_logs(vault.UpdateDepositHook))
 
     assert len(event) == 1
-    assert event[0].deposit_limit_module == deposit_limit_module
+    assert event[0].deposit_hook == deposit_hook
 
 
-def test_set_deposit_limit_module_with_limit__reverts(gov, vault, bunny):
+def test_set_deposit_hook_with_limit__reverts(gov, vault, bunny):
     # We temporarily give bunny the role
     tx = vault.set_role(bunny.address, ROLES.DEPOSIT_LIMIT_MANAGER, sender=gov)
 
@@ -240,10 +240,10 @@ def test_set_deposit_limit_module_with_limit__reverts(gov, vault, bunny):
     vault.set_deposit_limit(1, sender=gov)
 
     with ape.reverts("using deposit limit"):
-        vault.set_deposit_limit_module(bunny, sender=gov)
+        vault.set_deposit_hook(bunny, sender=gov)
 
 
-def test_set_deposit_limit_module_with_limit__override(gov, vault, bunny):
+def test_set_deposit_hook_with_limit__override(gov, vault, bunny):
     # We temporarily give bunny the role
     tx = vault.set_role(bunny.address, ROLES.DEPOSIT_LIMIT_MANAGER, sender=gov)
 
@@ -254,19 +254,19 @@ def test_set_deposit_limit_module_with_limit__override(gov, vault, bunny):
 
     vault.set_deposit_limit(1, sender=gov)
 
-    deposit_limit_module = bunny
+    deposit_hook = bunny
     with ape.reverts("using deposit limit"):
-        vault.set_deposit_limit_module(deposit_limit_module, sender=gov)
+        vault.set_deposit_hook(deposit_hook, sender=gov)
 
-    tx = vault.set_deposit_limit_module(deposit_limit_module, True, sender=gov)
+    tx = vault.set_deposit_hook(deposit_hook, True, sender=gov)
 
     assert vault.deposit_limit() == MAX_INT
-    assert vault.deposit_limit_module() == deposit_limit_module
+    assert vault.deposit_hook() == deposit_hook
 
-    event = list(tx.decode_logs(vault.UpdateDepositLimitModule))
+    event = list(tx.decode_logs(vault.UpdateDepositHook))
 
     assert len(event) == 1
-    assert event[0].deposit_limit_module == deposit_limit_module
+    assert event[0].deposit_hook == deposit_hook
 
     event = list(tx.decode_logs(vault.UpdateDepositLimit))
 
@@ -274,13 +274,13 @@ def test_set_deposit_limit_module_with_limit__override(gov, vault, bunny):
     assert event[0].deposit_limit == MAX_INT
 
 
-def test_set_withdraw_limit_module__no_withdraw_limit_manager__reverts(bunny, vault):
-    withdraw_limit_module = bunny
+def test_set_withdraw_hook__no_withdraw_limit_manager__reverts(bunny, vault):
+    withdraw_hook = bunny
     with ape.reverts("not allowed"):
-        vault.set_withdraw_limit_module(withdraw_limit_module, sender=bunny)
+        vault.set_withdraw_hook(withdraw_hook, sender=bunny)
 
 
-def test_set_withdraw_limit_module__withdraw_limit_manager(gov, vault, bunny):
+def test_set_withdraw_hook__withdraw_limit_manager(gov, vault, bunny):
     # We temporarily give bunny the role
     tx = vault.set_role(bunny.address, ROLES.WITHDRAW_LIMIT_MANAGER, sender=gov)
 
@@ -289,16 +289,16 @@ def test_set_withdraw_limit_module__withdraw_limit_manager(gov, vault, bunny):
     assert event[0].account == bunny.address
     assert event[0].role == ROLES.WITHDRAW_LIMIT_MANAGER
 
-    withdraw_limit_module = bunny
-    assert vault.withdraw_limit_module() == ZERO_ADDRESS
-    tx = vault.set_withdraw_limit_module(withdraw_limit_module, sender=bunny)
+    withdraw_hook = bunny
+    assert vault.withdraw_hook() == ZERO_ADDRESS
+    tx = vault.set_withdraw_hook(withdraw_hook, sender=bunny)
 
-    assert vault.withdraw_limit_module() == withdraw_limit_module
+    assert vault.withdraw_hook() == withdraw_hook
 
-    event = list(tx.decode_logs(vault.UpdateWithdrawLimitModule))
+    event = list(tx.decode_logs(vault.UpdateWithdrawHook))
 
     assert len(event) == 1
-    assert event[0].withdraw_limit_module == withdraw_limit_module
+    assert event[0].withdraw_hook == withdraw_hook
 
 
 # DEBT_PURCHASER

--- a/tests/unit/vault/test_strategy_withdraw.py
+++ b/tests/unit/vault/test_strategy_withdraw.py
@@ -617,6 +617,206 @@ def test_redeem__with_full_loss_strategy__withdraws_none(
     assert asset.balanceOf(fish) == amount_to_withdraw - amount_to_lose
 
 
+def test_withdraw__tiny_unrealised_loss_clamps_to_assets_needed(
+    gov,
+    fish,
+    bunny,
+    asset,
+    create_vault,
+    create_lossy_strategy,
+    user_deposit,
+    add_strategy_to_vault,
+    add_debt_to_strategy,
+    airdrop_asset,
+):
+    vault = create_vault(asset)
+    lossy_strategy = create_lossy_strategy(vault)
+    max_loss = 10_000
+
+    airdrop_asset(gov, asset, bunny, 1)
+    user_deposit(fish, vault, asset, 1)
+    user_deposit(bunny, vault, asset, 1)
+
+    vault.set_role(
+        gov.address,
+        ROLES.ADD_STRATEGY_MANAGER | ROLES.DEBT_MANAGER | ROLES.MAX_DEBT_MANAGER,
+        sender=gov,
+    )
+    add_strategy_to_vault(gov, lossy_strategy, vault)
+    add_debt_to_strategy(gov, lossy_strategy, vault, 2)
+
+    lossy_strategy.setLoss(gov, 1, sender=gov)
+
+    fish_balance = asset.balanceOf(fish)
+    tx = vault.withdraw(
+        1,
+        fish.address,
+        fish.address,
+        max_loss,
+        [lossy_strategy.address],
+        sender=fish,
+    )
+
+    event = list(tx.decode_logs(vault.Withdraw))
+    assert event[-1].shares == 1
+    assert event[-1].assets == 0
+
+    event = list(tx.decode_logs(vault.DebtUpdated))
+    assert len(event) == 1
+    assert event[0].strategy == lossy_strategy.address
+    assert event[0].current_debt == 2
+    assert event[0].new_debt == 1
+
+    assert asset.balanceOf(fish) == fish_balance
+    assert vault.balanceOf(fish) == 0
+    assert vault.balanceOf(bunny) == 1
+    assert vault.totalDebt() == 1
+    assert vault.strategies(lossy_strategy.address).current_debt == 1
+
+
+def test_withdraw__unrealised_loss_keeps_existing_conservative_rounding(
+    gov,
+    fish,
+    bunny,
+    asset,
+    create_vault,
+    create_lossy_strategy,
+    user_deposit,
+    add_strategy_to_vault,
+    add_debt_to_strategy,
+    airdrop_asset,
+):
+    vault = create_vault(asset)
+    lossy_strategy = create_lossy_strategy(vault)
+    max_loss = 10_000
+
+    airdrop_asset(gov, asset, bunny, 93)
+    user_deposit(fish, vault, asset, 7)
+    user_deposit(bunny, vault, asset, 93)
+
+    vault.set_role(
+        gov.address,
+        ROLES.ADD_STRATEGY_MANAGER | ROLES.DEBT_MANAGER | ROLES.MAX_DEBT_MANAGER,
+        sender=gov,
+    )
+    add_strategy_to_vault(gov, lossy_strategy, vault)
+    add_debt_to_strategy(gov, lossy_strategy, vault, 100)
+
+    lossy_strategy.setLoss(gov, 49, sender=gov)
+
+    fish_balance = asset.balanceOf(fish)
+    tx = vault.withdraw(
+        7,
+        fish.address,
+        fish.address,
+        max_loss,
+        [lossy_strategy.address],
+        sender=fish,
+    )
+
+    event = list(tx.decode_logs(vault.Withdraw))
+    assert event[-1].shares == 7
+    assert event[-1].assets == 2
+
+    event = list(tx.decode_logs(vault.DebtUpdated))
+    assert len(event) == 1
+    assert event[0].strategy == lossy_strategy.address
+    assert event[0].current_debt == 100
+    assert event[0].new_debt == 93
+
+    assert asset.balanceOf(fish) == fish_balance + 2
+    assert vault.balanceOf(fish) == 0
+    assert vault.totalDebt() == 93
+    assert vault.strategies(lossy_strategy.address).current_debt == 93
+
+
+def test_withdraw__max_redeem_adjustment_can_round_unrealised_loss_to_zero(
+    gov,
+    fish,
+    bunny,
+    asset,
+    create_vault,
+    create_strategy,
+    create_lossy_strategy,
+    user_deposit,
+    add_strategy_to_vault,
+    add_debt_to_strategy,
+    airdrop_asset,
+):
+    vault = create_vault(asset)
+    liquid_strategy = create_strategy(vault)
+    lossy_strategy = create_lossy_strategy(vault)
+    fish_deposit = 700
+    bunny_deposit = 19_300
+    strategy_debt = 10_000
+    loss = 100
+    locked_funds = 9_850
+    max_loss = 10_000
+
+    airdrop_asset(gov, asset, bunny, bunny_deposit)
+    user_deposit(fish, vault, asset, fish_deposit)
+    user_deposit(bunny, vault, asset, bunny_deposit)
+
+    vault.set_role(
+        gov.address,
+        ROLES.ADD_STRATEGY_MANAGER | ROLES.DEBT_MANAGER | ROLES.MAX_DEBT_MANAGER,
+        sender=gov,
+    )
+    add_strategy_to_vault(gov, lossy_strategy, vault)
+    add_strategy_to_vault(gov, liquid_strategy, vault)
+    add_debt_to_strategy(gov, lossy_strategy, vault, strategy_debt)
+    add_debt_to_strategy(gov, liquid_strategy, vault, strategy_debt)
+
+    lossy_strategy.setLoss(gov, loss, sender=gov)
+    lossy_strategy.setLockedFunds(locked_funds, sender=gov)
+
+    lossy_max_withdraw = lossy_strategy.convertToAssets(
+        lossy_strategy.maxRedeem(vault.address)
+    )
+    expected_initial_loss = fish_deposit - (
+        fish_deposit * (strategy_debt - loss) // strategy_debt
+    )
+    wanted_after_loss = fish_deposit - expected_initial_loss
+
+    assert expected_initial_loss == 7
+    assert 0 < lossy_max_withdraw < wanted_after_loss
+    assert expected_initial_loss * lossy_max_withdraw // wanted_after_loss == 0
+
+    fish_balance = asset.balanceOf(fish)
+    tx = vault.withdraw(
+        fish_deposit,
+        fish.address,
+        fish.address,
+        max_loss,
+        [lossy_strategy.address, liquid_strategy.address],
+        sender=fish,
+    )
+
+    event = list(tx.decode_logs(vault.Withdraw))
+    assert event[-1].shares == fish_deposit
+    assert event[-1].assets == fish_deposit
+
+    event = list(tx.decode_logs(vault.DebtUpdated))
+    assert len(event) == 2
+    assert event[0].strategy == lossy_strategy.address
+    assert event[0].current_debt == strategy_debt
+    assert event[0].new_debt == strategy_debt - lossy_max_withdraw
+    assert event[1].strategy == liquid_strategy.address
+    assert event[1].current_debt == strategy_debt
+    assert event[1].new_debt == strategy_debt - (fish_deposit - lossy_max_withdraw)
+
+    assert asset.balanceOf(fish) == fish_balance + fish_deposit
+    assert vault.balanceOf(fish) == 0
+    assert vault.balanceOf(bunny) == bunny_deposit
+    assert vault.totalDebt() == strategy_debt * 2 - fish_deposit
+    assert vault.strategies(lossy_strategy.address).current_debt == (
+        strategy_debt - lossy_max_withdraw
+    )
+    assert vault.strategies(liquid_strategy.address).current_debt == (
+        strategy_debt - (fish_deposit - lossy_max_withdraw)
+    )
+
+
 def test_withdraw__with_lossy_and_liquid_strategy__withdraws_less_than_deposited(
     gov,
     fish,

--- a/yarn.lock
+++ b/yarn.lock
@@ -419,11 +419,6 @@
     "@nomicfoundation/solidity-analyzer-win32-ia32-msvc" "0.1.0"
     "@nomicfoundation/solidity-analyzer-win32-x64-msvc" "0.1.0"
 
-"@openzeppelin/contracts@^4.9.5":
-  version "4.9.6"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.6.tgz#2a880a24eb19b4f8b25adc2a5095f2aa27f39677"
-  integrity sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA==
-
 "@scure/base@~1.1.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.1.tgz#ebb651ee52ff84f420097055f4bf46cfba403938"
@@ -544,11 +539,6 @@
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.1.tgz#c48c2e27b65d2a153b19bfc1a317e30872e01eef"
   integrity sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==
-
-"@types/minimatch@^3.0.3":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
-  integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
 "@types/node@*":
   version "18.14.0"
@@ -687,21 +677,6 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
-
-array-differ@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-3.0.0.tgz#3cbb3d0f316810eafcc47624734237d6aee4ae6b"
-  integrity sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==
-
-array-union@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
-  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
-
-arrify@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
-  integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
 ast-parents@^0.0.1:
   version "0.0.1"
@@ -908,14 +883,6 @@ chalk@^2.0.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
-  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
 chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -1016,11 +983,6 @@ commander@^10.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.0.tgz#71797971162cd3cf65f0b9d24eb28f8d303acdf1"
   integrity sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==
 
-commander@^8.1.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
-  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1069,15 +1031,6 @@ create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-spawn@^7.0.0:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
-  dependencies:
-    path-key "^3.1.0"
-    shebang-command "^2.0.0"
-    which "^2.0.1"
-
 debug@4, debug@4.3.4, debug@^4.1.1, debug@^4.3.3:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
@@ -1117,13 +1070,6 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-
-end-of-stream@^1.1.0:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
-  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
-  dependencies:
-    once "^1.4.0"
 
 enquirer@^2.3.0:
   version "2.3.6"
@@ -1232,21 +1178,6 @@ evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
-execa@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
-  integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
-  dependencies:
-    cross-spawn "^7.0.0"
-    get-stream "^5.0.0"
-    human-signals "^1.1.1"
-    is-stream "^2.0.0"
-    merge-stream "^2.0.0"
-    npm-run-path "^4.0.0"
-    onetime "^5.1.0"
-    signal-exit "^3.0.2"
-    strip-final-newline "^2.0.0"
-
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -1283,14 +1214,6 @@ find-up@^2.1.0:
   integrity sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==
   dependencies:
     locate-path "^2.0.0"
-
-find-up@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
-  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
-  dependencies:
-    locate-path "^5.0.0"
-    path-exists "^4.0.0"
 
 flat@^5.0.2:
   version "5.0.2"
@@ -1366,13 +1289,6 @@ get-intrinsic@^1.0.2:
     has "^1.0.3"
     has-symbols "^1.0.3"
 
-get-stream@^5.0.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
-  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
-  dependencies:
-    pump "^3.0.0"
-
 glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
@@ -1420,7 +1336,7 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-hardhat@^2.12.2:
+hardhat@2.12.7:
   version "2.12.7"
   resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.12.7.tgz#d8de2dc32e9a2956d53cf26ef4cd5857e57a3138"
   integrity sha512-voWoN6zn5d8BOEaczSyK/1PyfdeOeI3SbGCFb36yCHTJUt6OIqLb+ZDX30VhA1UsYKzLqG7UnWl3fKJUuANc6A==
@@ -1548,11 +1464,6 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-human-signals@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
-  integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
-
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -1565,7 +1476,7 @@ ieee754@^1.2.1:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
-ignore@^5.1.4, ignore@^5.2.4:
+ignore@^5.2.4:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
@@ -1657,20 +1568,10 @@ is-plain-obj@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
-is-stream@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
-  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
-
 is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
-
-isexe@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
-  integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
 js-sha3@0.8.0:
   version "0.8.0"
@@ -1768,13 +1669,6 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-locate-path@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
-  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
-  dependencies:
-    p-locate "^4.1.0"
-
 locate-path@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
@@ -1847,16 +1741,6 @@ memorystream@^0.3.1:
   resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
   integrity sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==
 
-merge-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
-  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
-
-mimic-fn@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
-  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
-
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -1927,11 +1811,6 @@ module-error@^1.0.1, module-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/module-error/-/module-error-1.0.2.tgz#8d1a48897ca883f47a45816d4fb3e3c6ba404d86"
   integrity sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==
 
-mri@^1.1.5:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
-  integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
-
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -1941,17 +1820,6 @@ ms@2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
-multimatch@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-4.0.0.tgz#8c3c0f6e3e8449ada0af3dd29efb491a375191b3"
-  integrity sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==
-  dependencies:
-    "@types/minimatch" "^3.0.3"
-    array-differ "^3.0.0"
-    array-union "^2.1.0"
-    arrify "^2.0.1"
-    minimatch "^3.0.4"
 
 nanoid@3.3.3:
   version "3.3.3"
@@ -1978,13 +1846,6 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
-npm-run-path@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
-  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
-  dependencies:
-    path-key "^3.0.0"
-
 object-inspect@^1.9.0:
   version "1.12.3"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
@@ -1995,19 +1856,12 @@ obliterator@^2.0.0:
   resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-2.0.4.tgz#fa650e019b2d075d745e44f1effeb13a2adbe816"
   integrity sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ==
 
-once@^1.3.0, once@^1.3.1, once@^1.4.0:
+once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
-
-onetime@^5.1.0:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
-  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
-  dependencies:
-    mimic-fn "^2.1.0"
 
 os-tmpdir@~1.0.2:
   version "1.0.2"
@@ -2020,13 +1874,6 @@ p-limit@^1.1.0:
   integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
   dependencies:
     p-try "^1.0.0"
-
-p-limit@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
-  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
-  dependencies:
-    p-try "^2.0.0"
 
 p-limit@^3.0.2:
   version "3.1.0"
@@ -2041,13 +1888,6 @@ p-locate@^2.0.0:
   integrity sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==
   dependencies:
     p-limit "^1.1.0"
-
-p-locate@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
-  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
-  dependencies:
-    p-limit "^2.2.0"
 
 p-locate@^5.0.0:
   version "5.0.0"
@@ -2067,11 +1907,6 @@ p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
   integrity sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==
-
-p-try@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
-  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -2104,11 +1939,6 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
-
-path-key@^3.0.0, path-key@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
-  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
 path-parse@^1.0.6:
   version "1.0.7"
@@ -2148,7 +1978,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier-plugin-solidity@^1.0.0-beta.19:
+prettier-plugin-solidity@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.1.2.tgz#452be4df925a4b16a974a04235839c9f56c2d10d"
   integrity sha512-KC5oNbFJfyBaFiO0kl56J6AXnDmr9tUlBV1iqo864x4KQrKYKaBZvW9jhT2oC0NHoNp7/GoMJNxqL8pp8k7C/g==
@@ -2157,30 +1987,10 @@ prettier-plugin-solidity@^1.0.0-beta.19:
     semver "^7.3.8"
     solidity-comments-extractor "^0.0.7"
 
-prettier@^2.6.0, prettier@^2.8.3:
+prettier@2.8.4, prettier@^2.8.3:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"
   integrity sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==
-
-pretty-quick@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/pretty-quick/-/pretty-quick-3.1.3.tgz#15281108c0ddf446675157ca40240099157b638e"
-  integrity sha512-kOCi2FJabvuh1as9enxYmrnBC6tVMoVOenMaBqRfsvBHB0cbpYHjdQEpSglpASDFEXVwplpcGR4CLEaisYAFcA==
-  dependencies:
-    chalk "^3.0.0"
-    execa "^4.0.0"
-    find-up "^4.1.0"
-    ignore "^5.1.4"
-    mri "^1.1.5"
-    multimatch "^4.0.0"
-
-pump@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
-  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
 
 punycode@^2.1.0:
   version "2.3.0"
@@ -2354,18 +2164,6 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shebang-command@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
-  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
-  dependencies:
-    shebang-regex "^3.0.0"
-
-shebang-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
-  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
-
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -2374,11 +2172,6 @@ side-channel@^1.0.4:
     call-bind "^1.0.0"
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
-
-signal-exit@^3.0.2:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
-  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
 slice-ansi@^4.0.0:
   version "4.0.0"
@@ -2404,31 +2197,14 @@ solc@0.7.3:
     semver "^5.5.0"
     tmp "0.0.33"
 
-solc@0.8.18:
-  version "0.8.18"
-  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.18.tgz#a05ce8918540eda5f10aa91f0f52f239b9645dad"
-  integrity sha512-wVAa2Y3BYd64Aby5LsgS3g6YC2NvZ3bJ+A8TAIAukfVuQb3AjyGrLZpyxQk5YLn14G35uZtSnIgHEpab9klOLQ==
-  dependencies:
-    command-exists "^1.2.8"
-    commander "^8.1.0"
-    follow-redirects "^1.12.1"
-    js-sha3 "0.8.0"
-    memorystream "^0.3.1"
-    semver "^5.5.0"
-    tmp "0.0.33"
-
-solhint-plugin-prettier@^0.0.5:
+solhint-plugin-prettier@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/solhint-plugin-prettier/-/solhint-plugin-prettier-0.0.5.tgz#e3b22800ba435cd640a9eca805a7f8bc3e3e6a6b"
   integrity sha512-7jmWcnVshIrO2FFinIvDQmhQpfpS2rRRn3RejiYgnjIE68xO2bvrYvjqVNfrio4xH9ghOqn83tKuTzLjEbmGIA==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-solhint-plugin-yearn@pandadefi/solhint-plugin-yearn:
-  version "0.1.0"
-  resolved "https://codeload.github.com/pandadefi/solhint-plugin-yearn/tar.gz/ed32146b56903898a48eadf752c8d5b34acc6b77"
-
-solhint@^3.3.7:
+solhint@3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/solhint/-/solhint-3.4.0.tgz#a7e4f2d73e679cb197a1ca5279aa7534bd323e4d"
   integrity sha512-FYEs/LoTxMsWFP/OGsEqR1CBDn3Bn7hrTWsgtjai17MzxITgearIdlo374KKZjjIycu8E2xBcJ+RSWeoBvQmkw==
@@ -2510,11 +2286,6 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
-
-strip-final-newline@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
-  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
 strip-hex-prefix@1.0.0:
   version "1.0.0"
@@ -2647,13 +2418,6 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-which@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
-  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
-  dependencies:
-    isexe "^2.0.0"
 
 workerpool@6.2.1:
   version "6.2.1"


### PR DESCRIPTION
- Fixes the withdrawal limit module queue bug by passing the effective withdrawal queue instead of a different queue than redemption uses.
- Fixes tiny unrealised-loss rounding so the assessed loss cannot round above the requested strategy withdrawal amount.
- Fixes stale strategy debt when unrealised loss consumes the full withdrawal slice.
- Adds emergency-manager pause functionality that blocks ERC4626 user flows while leaving share transfers and management operations available.
- Adds post deposit and withdraw hooks.
- Bump vyper version to 0.3.10