### PR TITLE
feat(vault): allow emergency manager pauses

### DIFF
--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -136,6 +136,9 @@ event UpdateUseDefaultQueue:
 event UpdateAutoAllocate:
     auto_allocate: bool
 
+event UpdatePaused:
+    paused: bool
+
 event UpdatedMaxDebtForStrategy:
     sender: indexed(address)
     strategy: indexed(address)
@@ -196,7 +199,7 @@ enum Roles:
     MINIMUM_IDLE_MANAGER # Sets the minimum total idle the vault should keep.
     PROFIT_UNLOCK_MANAGER # Sets the profit_max_unlock_time.
     DEBT_PURCHASER # Can purchase bad debt from the vault.
-    EMERGENCY_MANAGER # Can shutdown vault in an emergency.
+    EMERGENCY_MANAGER # Can shutdown or pause vault in an emergency.
 
 enum StrategyChangeType:
     ADDED
@@ -262,6 +265,8 @@ symbol: public(String[32])
 
 # State of the vault - if set to true, only withdrawals will be available. It can't be reverted.
 shutdown: bool
+# Reversible state that pauses ERC4626 user flows.
+paused: public(bool)
 # The amount of time profits will unlock over.
 profit_max_unlock_time: uint256
 # The timestamp of when the current unlocking period ends.
@@ -512,6 +517,9 @@ def _issue_shares(shares: uint256, recipient: address):
 @view
 @internal
 def _max_deposit(receiver: address) -> uint256: 
+    if self.paused:
+        return 0
+
     if receiver in [empty(address), self]:
         return 0
 
@@ -565,6 +573,8 @@ def _max_withdraw(
     out is 90, but a user of the vault will need to call withdraw with 100
     in order to get the full 90 out.
     """
+    if self.paused:
+        return 0
 
     # Get the max amount for the owner if fully liquid.
     max_assets: uint256 = self._convert_to_assets(self.balance_of[owner], Rounding.ROUND_DOWN)
@@ -741,6 +751,7 @@ def _redeem(
     to the user that is redeeming their vault shares unless it exceeds the given
     `max_loss`.
     """
+    assert not self.paused, "paused"
     assert receiver != empty(address), "ZERO ADDRESS"
     assert shares > 0, "no shares to redeem"
     assert assets > 0, "no assets to withdraw"
@@ -1603,6 +1614,16 @@ def isShutdown() -> bool:
     @return Bool representing the shutdown status
     """
     return self.shutdown
+
+@view
+@external
+def isPaused() -> bool:
+    """
+    @notice Get if the vault is paused.
+    @return Bool representing the paused status.
+    """
+    return self.paused
+
 @view
 @external
 def unlockedShares() -> uint256:
@@ -1761,6 +1782,16 @@ def update_debt(
     return self._update_debt(strategy, target_debt, max_loss)
 
 ## EMERGENCY MANAGEMENT ##
+@external
+def setPaused(paused: bool):
+    """
+    @notice Set the vault's paused status.
+    """
+    self._enforce_role(msg.sender, Roles.EMERGENCY_MANAGER)
+    self.paused = paused
+
+    log UpdatePaused(paused)
+
 @external
 def shutdown_vault():
     """

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -266,7 +266,7 @@ symbol: public(String[32])
 # State of the vault - if set to true, only withdrawals will be available. It can't be reverted.
 shutdown: bool
 # Reversible state that pauses ERC4626 user flows.
-paused: public(bool)
+paused: bool
 # The amount of time profits will unlock over.
 profit_max_unlock_time: uint256
 # The timestamp of when the current unlocking period ends.

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -77,8 +77,6 @@ interface IVault is IERC4626 {
 
     function isShutdown() external view returns (bool);
 
-    function paused() external view returns (bool);
-
     function isPaused() external view returns (bool);
 
     function nonces(address) external view returns (uint256);

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -39,6 +39,7 @@ interface IVault is IERC4626 {
     event UpdateMinimumTotalIdle(uint256 minimum_total_idle);
     event UpdateProfitMaxUnlockTime(uint256 profit_max_unlock_time);
     event DebtPurchased(address indexed strategy, uint256 amount);
+    event UpdatePaused(bool paused);
     event Shutdown();
 
     struct StrategyParams {
@@ -75,6 +76,10 @@ interface IVault is IERC4626 {
     function future_role_manager() external view returns (address);
 
     function isShutdown() external view returns (bool);
+
+    function paused() external view returns (bool);
+
+    function isPaused() external view returns (bool);
 
     function nonces(address) external view returns (uint256);
 
@@ -167,6 +172,8 @@ interface IVault is IERC4626 {
         uint256 target_debt,
         uint256 max_loss
     ) external returns (uint256);
+
+    function setPaused(bool paused) external;
 
     function shutdown_vault() external;
 

--- a/tests/unit/vault/test_pause.py
+++ b/tests/unit/vault/test_pause.py
@@ -1,0 +1,117 @@
+import ape
+from utils.constants import MAX_INT, ROLES
+
+
+def test_setPaused__no_emergency_manager__reverts(asset, create_vault, bunny):
+    vault = create_vault(asset)
+
+    with ape.reverts("not allowed"):
+        vault.setPaused(True, sender=bunny)
+
+
+def test_setPaused__emergency_manager(asset, create_vault, gov, bunny):
+    vault = create_vault(asset)
+    vault.set_role(bunny.address, ROLES.EMERGENCY_MANAGER, sender=gov)
+
+    assert vault.paused() == False
+    assert vault.isPaused() == False
+
+    tx = vault.setPaused(True, sender=bunny)
+    event = list(tx.decode_logs(vault.UpdatePaused))
+
+    assert len(event) == 1
+    assert event[0].paused == True
+    assert vault.paused() == True
+    assert vault.isPaused() == True
+
+    tx = vault.setPaused(False, sender=bunny)
+    event = list(tx.decode_logs(vault.UpdatePaused))
+
+    assert len(event) == 1
+    assert event[0].paused == False
+    assert vault.paused() == False
+    assert vault.isPaused() == False
+
+
+def test_paused_blocks_erc4626_user_flows(
+    asset, create_vault, fish, fish_amount, gov, mint_and_deposit_into_vault
+):
+    vault = create_vault(asset)
+    amount = fish_amount
+
+    mint_and_deposit_into_vault(vault, fish, amount)
+    vault.setPaused(True, sender=gov)
+
+    assert vault.maxDeposit(fish.address) == 0
+    assert vault.maxMint(fish.address) == 0
+    assert vault.maxWithdraw(fish.address) == 0
+    assert vault.maxRedeem(fish.address) == 0
+
+    with ape.reverts("exceed deposit limit"):
+        vault.deposit(amount, fish.address, sender=fish)
+
+    with ape.reverts("exceed deposit limit"):
+        vault.mint(amount, fish.address, sender=fish)
+
+    with ape.reverts("paused"):
+        vault.withdraw(amount, fish.address, fish.address, sender=fish)
+
+    with ape.reverts("paused"):
+        vault.redeem(amount, fish.address, fish.address, sender=fish)
+
+
+def test_unpause_restores_erc4626_user_flows(
+    asset, create_vault, fish, fish_amount, gov
+):
+    vault = create_vault(asset)
+    amount = fish_amount
+
+    vault.setPaused(True, sender=gov)
+    vault.setPaused(False, sender=gov)
+
+    asset.mint(fish.address, amount, sender=gov)
+    asset.approve(vault.address, amount, sender=fish)
+    vault.deposit(amount, fish.address, sender=fish)
+
+    assert vault.maxWithdraw(fish.address) == amount
+
+    vault.withdraw(amount, fish.address, fish.address, sender=fish)
+    assert vault.balanceOf(fish.address) == 0
+
+
+def test_paused_keeps_erc20_share_flows_live(
+    asset, create_vault, fish, fish_amount, bunny, gov, mint_and_deposit_into_vault
+):
+    vault = create_vault(asset)
+    amount = fish_amount
+    half = amount // 2
+
+    mint_and_deposit_into_vault(vault, fish, amount)
+    vault.setPaused(True, sender=gov)
+
+    vault.transfer(bunny.address, half, sender=fish)
+    vault.approve(bunny.address, half, sender=fish)
+    vault.transferFrom(fish.address, bunny.address, half, sender=bunny)
+
+    assert vault.balanceOf(fish.address) == 0
+    assert vault.balanceOf(bunny.address) == amount
+
+
+def test_paused_keeps_debt_management_live(
+    asset, create_vault, create_strategy, gov, mint_and_deposit_into_vault
+):
+    vault = create_vault(asset)
+    strategy = create_strategy(vault)
+    amount = 10**18
+
+    vault.add_strategy(strategy.address, sender=gov)
+    strategy.setMaxDebt(MAX_INT, sender=gov)
+    mint_and_deposit_into_vault(vault, gov, amount)
+
+    vault.setPaused(True, sender=gov)
+
+    vault.update_max_debt_for_strategy(strategy.address, amount, sender=gov)
+    vault.update_debt(strategy.address, amount, sender=gov)
+
+    assert vault.strategies(strategy.address).current_debt == amount
+    assert asset.balanceOf(strategy.address) == amount

--- a/tests/unit/vault/test_pause.py
+++ b/tests/unit/vault/test_pause.py
@@ -13,7 +13,6 @@ def test_setPaused__emergency_manager(asset, create_vault, gov, bunny):
     vault = create_vault(asset)
     vault.set_role(bunny.address, ROLES.EMERGENCY_MANAGER, sender=gov)
 
-    assert vault.paused() == False
     assert vault.isPaused() == False
 
     tx = vault.setPaused(True, sender=bunny)
@@ -21,7 +20,6 @@ def test_setPaused__emergency_manager(asset, create_vault, gov, bunny):
 
     assert len(event) == 1
     assert event[0].paused == True
-    assert vault.paused() == True
     assert vault.isPaused() == True
 
     tx = vault.setPaused(False, sender=bunny)
@@ -29,7 +27,6 @@ def test_setPaused__emergency_manager(asset, create_vault, gov, bunny):
 
     assert len(event) == 1
     assert event[0].paused == False
-    assert vault.paused() == False
     assert vault.isPaused() == False
 
 


### PR DESCRIPTION
- Adds an emergency-manager controlled pause with `setPaused(bool)`.
- Restricts pausing and unpausing to `EMERGENCY_MANAGER`.
- Adds `isPaused()` and `UpdatePaused(bool)` so integrations can read and track the pause state.
- Keeps `paused` as internal vault storage instead of exposing a public `paused()` getter.
- Blocks deposits and mints by returning zero from `_max_deposit`, so `deposit`, `mint`, `maxDeposit`, and `maxMint` all use the same pause gate.
- Blocks withdrawals and redemptions by returning zero from `_max_withdraw`, so `maxWithdraw` and `maxRedeem` share the same pause gate.
- Adds an execution guard in `_redeem` so `withdraw` and `redeem` revert while paused instead of only reporting zero max.
- Leaves ERC20 share transfers, approvals, permit, and vault management flows live while paused.
- Keeps pause independent from shutdown; shutdown behavior stays unchanged.
- Bumps vault API version references to `3.1.0` in `VaultV3`, `VaultFactory`, deploy metadata, and Ape dependency config.