### PR TITLE
feat: deposit and withdraw hooks

### DIFF
--- a/.github/workflows/foundry.yaml
+++ b/.github/workflows/foundry.yaml
@@ -25,6 +25,10 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: recursive
+
+      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
+        with:
+          python-version: '3.10'
         
       - name: Install Vyper
         run: pip install vyper==0.3.7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
         node-version: '18.x'
 
     - name: Install hardhat
-      run: npm ci hardhat
+      run: npm ci
 
     - name: output current installation
       run: pip freeze

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,9 +27,14 @@ jobs:
 
     - name: install requirements
       run: python3 -m pip install -r requirements.txt 
-    
-    - name: install plugins
-      run: ape plugins install .
+
+    - name: pin ape plugins
+      run: |
+        python3 -m pip install \
+          "eth-ape==0.8.25" \
+          "ape-solidity==0.8.5" \
+          "ape-vyper==0.8.12" \
+          "ape-hardhat==0.8.5"
 
     - name: install vyper compiler
       run: ape vyper vvm install 0.3.7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,6 +30,9 @@ jobs:
     
     - name: install plugins
       run: ape plugins install .
+
+    - name: install vyper compiler
+      run: ape vyper vvm install 0.3.7
     
     - name: Compile contracts
       # TODO: Force recompiles until ape compile caching is fixed

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,8 +44,10 @@ jobs:
       with:
         node-version: '18.x'
 
-    - name: Install hardhat
-      run: npm ci
+    - name: Install node dependencies
+      run: |
+        corepack enable
+        yarn install --frozen-lockfile
 
     - name: output current installation
       run: pip freeze

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
+
+    - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
       with:
         python-version: '3.10'
 

--- a/TECH_SPEC.md
+++ b/TECH_SPEC.md
@@ -8,7 +8,7 @@
 - Vault: ERC4626 compliant Smart contract that receives Assets from Depositors to then distribute them among the different Strategies added to the vault, managing accounting and Assets distribution. 
 - Role: the different flags an Account can have in the Vault so that the Account can do certain specific actions. Can be fulfilled by a smart contract or an EOA.
 - Accountant: smart contract that receives P&L reporting and returns shares and refunds to the strategy
-- Limit Modules: Add on smart contracts that can control the vaults deposit and withdraw limits dynamically.
+- Hooks: Add on smart contracts that can control vault deposit and withdraw limits dynamically and receive post-deposit or post-withdraw callbacks.
 
 # VaultV3 Specification
 The Vault code has been designed as an non-opinionated system to distribute funds of depositors into different opportunities (aka Strategies) and manage accounting in a robust way. That's all.
@@ -30,7 +30,7 @@ Example periphery contracts:
 - Role Manager: Governance contract that holds the vaults `role_manager` position to codify vault setup and ownership guidelines. (see [RoleManager](https://github.com/yearn/vault-periphery/tree/master/contracts/Managers))
 - Debt Allocator: a smart contract that optimizes between multiple strategies based on the optimal return. (see [DebAllocators](https://github.com/yearn/vault-periphery/tree/master/contracts/debtAllocators))
 - Safety Staking Module: a smart contract that allows players to sponsor specific strategies (so that they are added to the vault) by staking their YFI, making money if they do well and losing money if they don't.
-- Deposit Limit Module: Will dynamically adjust the deposit limit based on the depositor and arbitrary conditions.
+- Deposit Hook: Will dynamically adjust the deposit limit based on the depositor and arbitrary conditions, and can react after deposits.
 - ...
 ```
 ## Deployment
@@ -52,7 +52,7 @@ All deployment variables besides the `asset` can be updated post deployment.
 ### Deposits / Mints
 Users can deposit ASSET tokens to receive yvTokens (SHARES).
 
-Deposits are limited under depositLimit/depositLimitModule and shutdown parameters. Read below for details.
+Deposits are limited under depositLimit/depositHook and shutdown parameters. Read below for details.
 
 ### Withdrawals / Redeems
 Users can redeem their shares at any point in time if there is liquidity available. 
@@ -118,8 +118,8 @@ These are:
 - REPORTING_MANAGER: role that calls report for strategies
 - DEBT_MANAGER: role that adds and removes debt from strategies
 - MAX_DEBT_MANAGER: role that can set the max debt for a strategy
-- DEPOSIT_LIMIT_MANAGER: role that sets deposit limit or deposit limit module for the vault
-- WITHDRAW_LIMIT_MANAGER: role that sets the withdraw limit module for the vault.
+- DEPOSIT_LIMIT_MANAGER: role that sets deposit limit or deposit hook for the vault
+- WITHDRAW_LIMIT_MANAGER: role that sets the withdraw hook for the vault.
 - MINIMUM_IDLE_MANAGER: role that sets the minimum total idle the vault should keep
 - PROFIT_UNLOCK_MANAGER: role that sets the profit_max_unlock_time
 - DEBT_PURCHASER # can purchase bad debt from the vault
@@ -144,12 +144,12 @@ Revoked strategies will return all debt and stop being eligible to receive more.
 
 Force revoking a strategy is only used in cases of a faulty strategy that cannot otherwise have its current_debt reduced to 0. Force revoking a strategy will result in a loss being reported by the vault.
 
-#### Setting the modules/periphery contracts
+#### Setting the hooks/periphery contracts
 The accountant can be set by the ACCOUNTANT_MANAGER.
 
-A deposit_limit_module can be set by the DEPOSIT_LIMIT_MANAGER
+A deposit_hook can be set by the DEPOSIT_LIMIT_MANAGER
 
-A withdraw_limit_module can be set by the WITHDRAW_LIMIT_MANAGER
+A withdraw_hook can be set by the WITHDRAW_LIMIT_MANAGER
 
 These contracts are not needed for the vault to function but are optional add ons for optimal use.
 
@@ -186,16 +186,16 @@ Stored in strategies[strategy].max_debt
 When a debt re-balance is triggered, the Vault will cap the new target debt to this number (max_debt)
 
 #### Setting the deposit limit
-The DEPOSIT_LIMIT_MANAGER is in charge of setting the deposit_limit or a deposit_limit_module for the vault
+The DEPOSIT_LIMIT_MANAGER is in charge of setting the deposit_limit or a deposit_hook for the vault
 
 On deployment deposit_limit defaults to 0 and will need to be increased to make the vault functional
 
-The deposit_limit will have to be set to MAX_UINT256 in order to set a deposit_limit_module, and the module will have to be address 0 to adjust the deposit_limit. Or the DEPOSIT_LIMIT_MANAGER can use the option `override` flags to do this in one step.
+The deposit_limit will have to be set to MAX_UINT256 in order to set a deposit_hook, and the hook will have to be address 0 to adjust the deposit_limit. Or the DEPOSIT_LIMIT_MANAGER can use the option `override` flags to do this in one step.
 
-#### Setting the withdraw limit module
-The WITHDRAW_LIMIT_MANAGER is in charge of setting the withdraw_limit_module for the vault
+#### Setting the withdraw hook
+The WITHDRAW_LIMIT_MANAGER is in charge of setting the withdraw_hook for the vault
 
-The vaults default withdraw limit is calculated based on the liquidity of its strategies. Setting a withdraw limit module will override this functionality.
+The vaults default withdraw limit is calculated based on the liquidity of its strategies. Setting a withdraw hook will override this functionality.
 
 #### Setting minimum idle funds
 The MINIMUM_IDLE_MANAGER can specify how many funds the vault should try to have reserved to serve withdrawal requests

--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -15,9 +15,14 @@ dependencies:
     ref: v3.0.4
     config_override:
       contracts_folder: src
+      solidity:
+        import_remapping:
+          - "@openzeppelin=contracts/.cache/openzeppelin/v4.9.5"
 
 solidity:
   version: 0.8.18
+  import_remapping:
+    - "@openzeppelin=contracts/.cache/openzeppelin/v4.9.5"
 
 ethereum:
   evm_version: paris

--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -12,7 +12,7 @@ dependencies:
     ref: 4.9.5
   - name: tokenized-strategy
     github: yearn/tokenized-strategy
-    ref: v3.1.0
+    ref: v3.0.4
     config_override:
       contracts_folder: src
 

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -51,11 +51,13 @@ interface IStrategy:
 interface IAccountant:
     def report(strategy: address, gain: uint256, loss: uint256) -> (uint256, uint256): nonpayable
 
-interface IDepositLimitModule:
+interface IDepositHook:
     def available_deposit_limit(receiver: address) -> uint256: view
+    def post_deposit(sender: address, receiver: address, assets: uint256, shares: uint256): nonpayable
     
-interface IWithdrawLimitModule:
+interface IWithdrawHook:
     def available_withdraw_limit(owner: address, max_loss: uint256, strategies: DynArray[address, MAX_QUEUE]) -> uint256: view
+    def post_withdraw(sender: address, receiver: address, owner: address, assets: uint256, shares: uint256): nonpayable
 
 interface IFactory:
     def protocol_fee_config() -> (uint16, address): view
@@ -121,11 +123,11 @@ event UpdateRoleManager:
 event UpdateAccountant:
     accountant: indexed(address)
 
-event UpdateDepositLimitModule:
-    deposit_limit_module: indexed(address)
+event UpdateDepositHook:
+    deposit_hook: indexed(address)
 
-event UpdateWithdrawLimitModule:
-    withdraw_limit_module: indexed(address)
+event UpdateWithdrawHook:
+    withdraw_hook: indexed(address)
 
 event UpdateDefaultQueue:
     new_default_queue: DynArray[address, MAX_QUEUE]
@@ -194,8 +196,8 @@ enum Roles:
     REPORTING_MANAGER # Calls report for strategies.
     DEBT_MANAGER # Adds and removes debt from strategies.
     MAX_DEBT_MANAGER # Can set the max debt for a strategy.
-    DEPOSIT_LIMIT_MANAGER # Sets deposit limit and module for the vault.
-    WITHDRAW_LIMIT_MANAGER # Sets the withdraw limit module.
+    DEPOSIT_LIMIT_MANAGER # Sets deposit limit and deposit hook for the vault.
+    WITHDRAW_LIMIT_MANAGER # Sets the withdraw hook.
     MINIMUM_IDLE_MANAGER # Sets the minimum total idle the vault should keep.
     PROFIT_UNLOCK_MANAGER # Sets the profit_max_unlock_time.
     DEBT_PURCHASER # Can purchase bad debt from the vault.
@@ -245,10 +247,10 @@ deposit_limit: public(uint256)
 ### PERIPHERY ###
 # Contract that charges fees and can give refunds.
 accountant: public(address)
-# Contract to control the deposit limit.
-deposit_limit_module: public(address)
-# Contract to control the withdraw limit.
-withdraw_limit_module: public(address)
+# Contract to control the deposit limit and receive post-deposit callbacks.
+deposit_hook: public(address)
+# Contract to control the withdraw limit and receive post-withdraw callbacks.
+withdraw_hook: public(address)
 
 ### ROLES ###
 # HashMap mapping addresses to their roles
@@ -523,10 +525,10 @@ def _max_deposit(receiver: address) -> uint256:
     if receiver in [empty(address), self]:
         return 0
 
-    # If there is a deposit limit module set use that.
-    deposit_limit_module: address = self.deposit_limit_module
-    if deposit_limit_module != empty(address):
-        return IDepositLimitModule(deposit_limit_module).available_deposit_limit(receiver)
+    # If there is a deposit hook set use that.
+    deposit_hook: address = self.deposit_hook
+    if deposit_hook != empty(address):
+        return IDepositHook(deposit_hook).available_deposit_limit(receiver)
     
     # Else use the standard flow.
     _deposit_limit: uint256 = self.deposit_limit
@@ -579,15 +581,15 @@ def _max_withdraw(
     # Get the max amount for the owner if fully liquid.
     max_assets: uint256 = self._convert_to_assets(self.balance_of[owner], Rounding.ROUND_DOWN)
 
-    # If there is a withdraw limit module use that.
-    withdraw_limit_module: address = self.withdraw_limit_module
+    # If there is a withdraw hook use that.
+    withdraw_hook: address = self.withdraw_hook
     # Use the same queue that a redemption would use.
     _strategies: DynArray[address, MAX_QUEUE] = self._withdraw_queue(strategies)
-    if withdraw_limit_module != empty(address):
+    if withdraw_hook != empty(address):
         return min(
             # Use the min between the returned value and the max.
-            # Means the limit module doesn't need to account for balances or conversions.
-            IWithdrawLimitModule(withdraw_limit_module).available_withdraw_limit(owner, max_loss, _strategies),
+            # Means the hook doesn't need to account for balances or conversions.
+            IWithdrawHook(withdraw_hook).available_withdraw_limit(owner, max_loss, _strategies),
             max_assets
         )
     
@@ -680,6 +682,10 @@ def _deposit(recipient: address, assets: uint256, shares: uint256):
     if self.auto_allocate:
         self._update_debt(self.default_queue[0], max_value(uint256), 0)
 
+    deposit_hook: address = self.deposit_hook
+    if deposit_hook != empty(address):
+        IDepositHook(deposit_hook).post_deposit(msg.sender, recipient, assets, shares)
+
 @view
 @internal
 def _assess_share_of_unrealised_losses(strategy: address, strategy_current_debt: uint256, assets_needed: uint256) -> uint256:
@@ -757,12 +763,12 @@ def _redeem(
     assert assets > 0, "no assets to withdraw"
     assert max_loss <= MAX_BPS, "max loss"
     
-    # If there is a withdraw limit module, check the max.
-    withdraw_limit_module: address = self.withdraw_limit_module
+    # If there is a withdraw hook, check the max.
+    withdraw_hook: address = self.withdraw_hook
     _strategies: DynArray[address, MAX_QUEUE] = self._withdraw_queue(strategies)
     
-    if withdraw_limit_module != empty(address):
-        assert assets <= IWithdrawLimitModule(withdraw_limit_module).available_withdraw_limit(owner, max_loss, _strategies), "exceed withdraw limit"
+    if withdraw_hook != empty(address):
+        assert assets <= IWithdrawHook(withdraw_hook).available_withdraw_limit(owner, max_loss, _strategies), "exceed withdraw limit"
 
     assert self.balance_of[owner] >= shares, "insufficient shares to redeem"
     
@@ -916,6 +922,10 @@ def _redeem(
     self._erc20_safe_transfer(_asset, receiver, requested_assets)
 
     log Withdraw(sender, receiver, owner, requested_assets, shares)
+
+    if withdraw_hook != empty(address):
+        IWithdrawHook(withdraw_hook).post_withdraw(sender, receiver, owner, requested_assets, shares)
+
     return requested_assets
 
 ## STRATEGY MANAGEMENT ##
@@ -1420,37 +1430,37 @@ def set_auto_allocate(auto_allocate: bool):
 def set_deposit_limit(deposit_limit: uint256, override: bool = False):
     """
     @notice Set the new deposit limit.
-    @dev Can not be changed if a deposit_limit_module
+    @dev Can not be changed if a deposit_hook
     is set unless the override flag is true or if shutdown.
     @param deposit_limit The new deposit limit.
-    @param override If a `deposit_limit_module` already set should be overridden.
+    @param override If a `deposit_hook` already set should be overridden.
     """
     assert self.shutdown == False # Dev: shutdown
     self._enforce_role(msg.sender, Roles.DEPOSIT_LIMIT_MANAGER)
 
-    # If we are overriding the deposit limit module.
+    # If we are overriding the deposit hook.
     if override:
         # Make sure it is set to address 0 if not already.
-        if self.deposit_limit_module != empty(address):
+        if self.deposit_hook != empty(address):
 
-            self.deposit_limit_module = empty(address)
-            log UpdateDepositLimitModule(empty(address))
+            self.deposit_hook = empty(address)
+            log UpdateDepositHook(empty(address))
     else:  
-        # Make sure the deposit_limit_module has been set to address(0).
-        assert self.deposit_limit_module == empty(address), "using module"
+        # Make sure the deposit_hook has been set to address(0).
+        assert self.deposit_hook == empty(address), "using hook"
 
     self.deposit_limit = deposit_limit
 
     log UpdateDepositLimit(deposit_limit)
 
 @external
-def set_deposit_limit_module(deposit_limit_module: address, override: bool = False):
+def set_deposit_hook(deposit_hook: address, override: bool = False):
     """
-    @notice Set a contract to handle the deposit limit.
+    @notice Set a contract to handle the deposit limit and post-deposit hook.
     @dev The default `deposit_limit` will need to be set to
-    max uint256 since the module will override it or the override flag
+    max uint256 since the hook will override it or the override flag
     must be set to true to set it to max in 1 tx..
-    @param deposit_limit_module Address of the module.
+    @param deposit_hook Address of the hook.
     @param override If a `deposit_limit` already set should be overridden.
     """
     assert self.shutdown == False # Dev: shutdown
@@ -1467,22 +1477,22 @@ def set_deposit_limit_module(deposit_limit_module: address, override: bool = Fal
         # Make sure the deposit_limit has been set to uint max.
         assert self.deposit_limit == max_value(uint256), "using deposit limit"
 
-    self.deposit_limit_module = deposit_limit_module
+    self.deposit_hook = deposit_hook
 
-    log UpdateDepositLimitModule(deposit_limit_module)
+    log UpdateDepositHook(deposit_hook)
 
 @external
-def set_withdraw_limit_module(withdraw_limit_module: address):
+def set_withdraw_hook(withdraw_hook: address):
     """
-    @notice Set a contract to handle the withdraw limit.
+    @notice Set a contract to handle the withdraw limit and post-withdraw hook.
     @dev This will override the default `max_withdraw`.
-    @param withdraw_limit_module Address of the module.
+    @param withdraw_hook Address of the hook.
     """
     self._enforce_role(msg.sender, Roles.WITHDRAW_LIMIT_MANAGER)
 
-    self.withdraw_limit_module = withdraw_limit_module
+    self.withdraw_hook = withdraw_hook
 
-    log UpdateWithdrawLimitModule(withdraw_limit_module)
+    log UpdateWithdrawHook(withdraw_hook)
 
 @external
 def set_minimum_total_idle(minimum_total_idle: uint256):
@@ -1804,10 +1814,10 @@ def shutdown_vault():
     self.shutdown = True
 
     # Set deposit limit to 0.
-    if self.deposit_limit_module != empty(address):
-        self.deposit_limit_module = empty(address)
+    if self.deposit_hook != empty(address):
+        self.deposit_hook = empty(address)
 
-        log UpdateDepositLimitModule(empty(address))
+        log UpdateDepositHook(empty(address))
 
     self.deposit_limit = 0
     log UpdateDepositLimit(0)

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -27,6 +27,8 @@ interface IVault is IERC4626 {
     event UpdateRoleManager(address indexed role_manager);
 
     event UpdateAccountant(address indexed accountant);
+    event UpdateDepositHook(address indexed deposit_hook);
+    event UpdateWithdrawHook(address indexed withdraw_hook);
     event UpdateDefaultQueue(address[] new_default_queue);
     event UpdateUseDefaultQueue(bool use_default_queue);
     event UpdatedMaxDebtForStrategy(
@@ -63,9 +65,9 @@ interface IVault is IERC4626 {
 
     function deposit_limit() external view returns (uint256);
 
-    function deposit_limit_module() external view returns (address);
+    function deposit_hook() external view returns (address);
 
-    function withdraw_limit_module() external view returns (address);
+    function withdraw_hook() external view returns (address);
 
     function accountant() external view returns (address);
 
@@ -108,18 +110,14 @@ interface IVault is IERC4626 {
         bool should_override
     ) external;
 
-    function set_deposit_limit_module(
-        address new_deposit_limit_module
-    ) external;
+    function set_deposit_hook(address new_deposit_hook) external;
 
-    function set_deposit_limit_module(
-        address new_deposit_limit_module,
+    function set_deposit_hook(
+        address new_deposit_hook,
         bool should_override
     ) external;
 
-    function set_withdraw_limit_module(
-        address new_withdraw_limit_module
-    ) external;
+    function set_withdraw_hook(address new_withdraw_hook) external;
 
     function set_minimum_total_idle(uint256 minimum_total_idle) external;
 

--- a/contracts/test/mocks/periphery/HookModule.vy
+++ b/contracts/test/mocks/periphery/HookModule.vy
@@ -13,6 +13,32 @@ default_withdraw_limit: public(uint256)
 
 required_withdraw_strategy: public(address)
 
+last_deposit_sender: public(address)
+
+last_deposit_receiver: public(address)
+
+last_deposit_assets: public(uint256)
+
+last_deposit_shares: public(uint256)
+
+post_deposit_count: public(uint256)
+
+last_withdraw_sender: public(address)
+
+last_withdraw_receiver: public(address)
+
+last_withdraw_owner: public(address)
+
+last_withdraw_assets: public(uint256)
+
+last_withdraw_shares: public(uint256)
+
+post_withdraw_count: public(uint256)
+
+revert_post_deposit: public(bool)
+
+revert_post_withdraw: public(bool)
+
 @external
 def __init__(
     default_deposit_limit: uint256,
@@ -30,8 +56,8 @@ def available_deposit_limit(receiver: address) -> uint256:
         if not self.whitelist[receiver]:
             return 0
 
-    if self.default_deposit_limit == MAX_UINT256:
-        return MAX_UINT256
+    if self.default_deposit_limit == max_value(uint256):
+        return max_value(uint256)
         
     return self.default_deposit_limit - IVault(msg.sender).totalAssets()
 
@@ -45,6 +71,27 @@ def available_withdraw_limit(owner: address, max_loss: uint256, strategies: DynA
             return 0
 
     return self.default_withdraw_limit
+
+@external
+def post_deposit(sender: address, receiver: address, assets: uint256, shares: uint256):
+    assert not self.revert_post_deposit, "post deposit revert"
+
+    self.last_deposit_sender = sender
+    self.last_deposit_receiver = receiver
+    self.last_deposit_assets = assets
+    self.last_deposit_shares = shares
+    self.post_deposit_count += 1
+
+@external
+def post_withdraw(sender: address, receiver: address, owner: address, assets: uint256, shares: uint256):
+    assert not self.revert_post_withdraw, "post withdraw revert"
+
+    self.last_withdraw_sender = sender
+    self.last_withdraw_receiver = receiver
+    self.last_withdraw_owner = owner
+    self.last_withdraw_assets = assets
+    self.last_withdraw_shares = shares
+    self.post_withdraw_count += 1
 
 @external
 def set_whitelist(list: address):
@@ -65,3 +112,11 @@ def set_required_withdraw_strategy(strategy: address):
 @external
 def set_enforce_whitelist(enforce: bool):
     self.enforce_whitelist = enforce
+
+@external
+def set_revert_post_deposit(should_revert: bool):
+    self.revert_post_deposit = should_revert
+
+@external
+def set_revert_post_withdraw(should_revert: bool):
+    self.revert_post_withdraw = should_revert

--- a/foundry.toml
+++ b/foundry.toml
@@ -16,6 +16,7 @@ fs_permissions = [{ access = "read", path = "./"}]
 
 #match_contract = "VaultERC4626StdTest"
 match_path = "./foundry_tests/tests/*"
+no_match_test = "testFail"
 ffi = true
 
 [fuzz]

--- a/foundry_tests/tests/ERC4626Std.t.sol
+++ b/foundry_tests/tests/ERC4626Std.t.sol
@@ -30,32 +30,50 @@ contract VaultERC4626StdTest is ERC4626Test, Setup {
     }
 
     //Avoid special case for deposits of uint256 max
-    function test_previewDeposit(
-        Init memory init,
-        uint assets
-    ) public override {
+    function test_previewDeposit(Init memory init, uint256 assets) public override {
         if (assets == type(uint256).max) assets -= 1;
         super.test_previewDeposit(init, assets);
     }
 
-    function test_deposit(
-        Init memory init,
-        uint assets,
-        uint allowance
-    ) public override {
+    function test_deposit(Init memory init, uint256 assets, uint256 allowance) public override {
         if (assets == type(uint256).max) assets -= 1;
         super.test_deposit(init, assets, allowance);
     }
 
-    function clamp(
-        Init memory init,
-        uint max
-    ) internal pure returns (Init memory) {
-        for (uint i = 0; i < N; i++) {
+    function test_RevertWhen_withdrawWithoutAllowance(Init memory init, uint256 assets) public {
+        setUpVault(init);
+        address caller = init.user[0];
+        address receiver = init.user[1];
+        address owner = init.user[2];
+        assets = bound(assets, 0, _max_withdraw(owner));
+        vm.assume(caller != owner);
+        vm.assume(assets > 0);
+        _approve(_vault_, owner, caller, 0);
+        vm.prank(caller);
+        vm.expectRevert();
+        IERC4626(_vault_).withdraw(assets, receiver, owner);
+    }
+
+    function test_RevertWhen_redeemWithoutAllowance(Init memory init, uint256 shares) public {
+        setUpVault(init);
+        address caller = init.user[0];
+        address receiver = init.user[1];
+        address owner = init.user[2];
+        shares = bound(shares, 0, _max_redeem(owner));
+        vm.assume(caller != owner);
+        vm.assume(shares > 0);
+        _approve(_vault_, owner, caller, 0);
+        vm.prank(caller);
+        vm.expectRevert();
+        IERC4626(_vault_).redeem(shares, receiver, owner);
+    }
+
+    function clamp(Init memory init, uint256 max) internal pure returns (Init memory) {
+        for (uint256 i = 0; i < N; i++) {
             init.share[i] = init.share[i] % max;
             init.asset[i] = init.asset[i] % max;
         }
-        init.yield = init.yield % int(max);
+        init.yield = init.yield % int256(max);
         return init;
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 black==22.3.0
+click==8.1.8
 eth-ape==0.8.10
 vyper==0.3.7
 eth-typing==3.5.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -358,16 +358,16 @@ def deploy_faulty_accountant(project, gov):
 
 
 @pytest.fixture(scope="session")
-def deploy_limit_module(project, gov):
-    def deploy_limit_module(
+def deploy_hook(project, gov):
+    def deploy_hook(
         deposit_limit=MAX_INT, withdraw_limit=MAX_INT, whitelist=False
     ):
-        limit_module = gov.deploy(
-            project.LimitModule, deposit_limit, withdraw_limit, whitelist
+        hook = gov.deploy(
+            project.HookModule, deposit_limit, withdraw_limit, whitelist
         )
-        return limit_module
+        return hook
 
-    yield deploy_limit_module
+    yield deploy_hook
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -359,12 +359,8 @@ def deploy_faulty_accountant(project, gov):
 
 @pytest.fixture(scope="session")
 def deploy_hook(project, gov):
-    def deploy_hook(
-        deposit_limit=MAX_INT, withdraw_limit=MAX_INT, whitelist=False
-    ):
-        hook = gov.deploy(
-            project.HookModule, deposit_limit, withdraw_limit, whitelist
-        )
+    def deploy_hook(deposit_limit=MAX_INT, withdraw_limit=MAX_INT, whitelist=False):
+        hook = gov.deploy(project.HookModule, deposit_limit, withdraw_limit, whitelist)
         return hook
 
     yield deploy_hook

--- a/tests/unit/vault/test_emergency_shutdown.py
+++ b/tests/unit/vault/test_emergency_shutdown.py
@@ -53,8 +53,8 @@ def test_shutdown__increase_deposit_limit__reverts(
     assert vault.maxDeposit(gov) == 0
 
 
-def test_shutdown__set_deposit_limit_module__reverts(
-    vault, gov, asset, mint_and_deposit_into_vault, deploy_limit_module
+def test_shutdown__set_deposit_hook__reverts(
+    vault, gov, asset, mint_and_deposit_into_vault, deploy_hook
 ):
     mint_and_deposit_into_vault(vault, gov)
     vault.shutdown_vault(sender=gov)
@@ -65,34 +65,34 @@ def test_shutdown__set_deposit_limit_module__reverts(
 
     assert ROLES.DEPOSIT_LIMIT_MANAGER in ROLES(vault.roles(gov))
 
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
 
     with ape.reverts():
-        vault.set_deposit_limit_module(limit_module, sender=gov)
+        vault.set_deposit_hook(hook, sender=gov)
 
     assert vault.maxDeposit(gov) == 0
 
 
-def test_shutdown__deposit_limit_module_is_removed(
-    create_vault, gov, asset, mint_and_deposit_into_vault, deploy_limit_module
+def test_shutdown__deposit_hook_is_removed(
+    create_vault, gov, asset, mint_and_deposit_into_vault, deploy_hook
 ):
     vault = create_vault(asset)
 
     mint_and_deposit_into_vault(vault, gov)
 
-    limit_module = deploy_limit_module()
-    vault.set_deposit_limit_module(limit_module, sender=gov)
+    hook = deploy_hook()
+    vault.set_deposit_hook(hook, sender=gov)
 
     assert vault.maxDeposit(gov) > 0
 
     tx = vault.shutdown_vault(sender=gov)
 
-    event = list(tx.decode_logs(vault.UpdateDepositLimitModule))
+    event = list(tx.decode_logs(vault.UpdateDepositHook))
 
     assert len(event) == 1
-    assert event[0].deposit_limit_module == ZERO_ADDRESS
+    assert event[0].deposit_hook == ZERO_ADDRESS
 
-    assert vault.deposit_limit_module() == ZERO_ADDRESS
+    assert vault.deposit_hook() == ZERO_ADDRESS
     assert vault.maxDeposit(gov) == 0
 
 

--- a/tests/unit/vault/test_erc4626.py
+++ b/tests/unit/vault/test_erc4626.py
@@ -648,27 +648,27 @@ def test_max_redeem__with_use_default_queue(
     assert vault.maxRedeem(fish.address, 22, [vault]) == assets
 
 
-# With limit modules
+# With hooks
 
 
-def test_max_deposit__with_deposit_limit_module(
-    asset, fish, fish_amount, gov, create_vault, deploy_limit_module, user_deposit
+def test_max_deposit__with_deposit_hook(
+    asset, fish, fish_amount, gov, create_vault, deploy_hook, user_deposit
 ):
     vault = create_vault(asset, deposit_limit=0)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
     assets = fish_amount
 
     assert vault.deposit_limit() == 0
     assert vault.maxDeposit(fish.address) == 0
 
     vault.set_deposit_limit(MAX_INT, sender=gov)
-    vault.set_deposit_limit_module(limit_module, sender=gov)
+    vault.set_deposit_hook(hook, sender=gov)
 
-    assert vault.deposit_limit_module() == limit_module.address
+    assert vault.deposit_hook() == hook.address
     assert vault.maxDeposit(fish.address) == MAX_INT
 
     new_limit = assets * 2
-    limit_module.set_default_deposit_limit(new_limit, sender=gov)
+    hook.set_default_deposit_limit(new_limit, sender=gov)
 
     user_deposit(fish, vault, asset, assets)
 
@@ -679,34 +679,34 @@ def test_max_deposit__with_deposit_limit_module(
     assert vault.maxDeposit(vault.address) == 0
 
     # If not on a whitelist it reverts.
-    limit_module.set_enforce_whitelist(True, sender=gov)
+    hook.set_enforce_whitelist(True, sender=gov)
 
     assert vault.maxDeposit(fish.address) == 0
 
     # If whitelisted it now works
-    limit_module.set_whitelist(fish.address, sender=gov)
+    hook.set_whitelist(fish.address, sender=gov)
 
     assert vault.maxDeposit(fish.address) == new_limit - assets
 
 
-def test_max_mint__with_deposit_limit_module(
-    asset, fish, fish_amount, gov, create_vault, deploy_limit_module, user_deposit
+def test_max_mint__with_deposit_hook(
+    asset, fish, fish_amount, gov, create_vault, deploy_hook, user_deposit
 ):
     vault = create_vault(asset, deposit_limit=0)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
     assets = fish_amount
 
     assert vault.deposit_limit() == 0
     assert vault.maxMint(fish.address) == 0
 
     vault.set_deposit_limit(MAX_INT, sender=gov)
-    vault.set_deposit_limit_module(limit_module, sender=gov)
+    vault.set_deposit_hook(hook, sender=gov)
 
-    assert vault.deposit_limit_module() == limit_module.address
+    assert vault.deposit_hook() == hook.address
     assert vault.maxDeposit(fish.address) == MAX_INT
 
     new_limit = assets * 2
-    limit_module.set_default_deposit_limit(new_limit, sender=gov)
+    hook.set_default_deposit_limit(new_limit, sender=gov)
 
     user_deposit(fish, vault, asset, assets)
 
@@ -717,47 +717,47 @@ def test_max_mint__with_deposit_limit_module(
     assert vault.maxMint(vault.address) == 0
 
     # If not on a whitelist it reverts.
-    limit_module.set_enforce_whitelist(True, sender=gov)
+    hook.set_enforce_whitelist(True, sender=gov)
 
     assert vault.maxMint(fish.address) == 0
 
     # If whitelisted it now works
-    limit_module.set_whitelist(fish.address, sender=gov)
+    hook.set_whitelist(fish.address, sender=gov)
 
     assert vault.maxMint(fish.address) == new_limit - assets
 
 
-def test_max_withdraw__with_withdraw_limit_module(
+def test_max_withdraw__with_withdraw_hook(
     asset,
     fish,
     bunny,
     fish_amount,
     gov,
     create_vault,
-    deploy_limit_module,
+    deploy_hook,
     user_deposit,
 ):
     vault = create_vault(asset)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
     assets = fish_amount // 2
 
     assert vault.maxWithdraw(fish.address) == 0
 
-    vault.set_withdraw_limit_module(limit_module, sender=gov)
+    vault.set_withdraw_hook(hook, sender=gov)
 
-    assert vault.withdraw_limit_module() == limit_module.address
+    assert vault.withdraw_hook() == hook.address
     # Max withdraw should still be 0
     assert vault.maxWithdraw(fish.address) == 0
 
     user_deposit(fish, vault, asset, assets)
 
     # Max should be uint max but amount is brought down based on balances.
-    assert limit_module.default_withdraw_limit() == MAX_INT
+    assert hook.default_withdraw_limit() == MAX_INT
     assert vault.maxWithdraw(fish.address) == assets
     assert vault.maxWithdraw(bunny.address) == 0
 
     new_limit = assets * 2
-    limit_module.set_default_withdraw_limit(new_limit, sender=gov)
+    hook.set_default_withdraw_limit(new_limit, sender=gov)
 
     # Doesn't change
     assert vault.maxWithdraw(fish.address) == assets
@@ -766,44 +766,44 @@ def test_max_withdraw__with_withdraw_limit_module(
 
     # Set limit below the balance
     new_limit = assets // 2
-    limit_module.set_default_withdraw_limit(new_limit, sender=gov)
+    hook.set_default_withdraw_limit(new_limit, sender=gov)
 
     assert vault.maxWithdraw(fish.address) == new_limit
     assert vault.maxWithdraw(fish.address, 23, [vault]) == new_limit
     assert vault.maxWithdraw(bunny.address) == 0
 
 
-def test_max_redeem__with_withdraw_limit_module(
+def test_max_redeem__with_withdraw_hook(
     asset,
     fish,
     bunny,
     fish_amount,
     gov,
     create_vault,
-    deploy_limit_module,
+    deploy_hook,
     user_deposit,
 ):
     vault = create_vault(asset)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
     assets = fish_amount // 2
 
     assert vault.maxRedeem(fish.address) == 0
 
-    vault.set_withdraw_limit_module(limit_module, sender=gov)
+    vault.set_withdraw_hook(hook, sender=gov)
 
-    assert vault.withdraw_limit_module() == limit_module.address
+    assert vault.withdraw_hook() == hook.address
     # Max withdraw should still be 0
     assert vault.maxRedeem(fish.address) == 0
 
     user_deposit(fish, vault, asset, assets)
 
     # Max should be uint max but amount is brought down based on balances.
-    assert limit_module.default_withdraw_limit() == MAX_INT
+    assert hook.default_withdraw_limit() == MAX_INT
     assert vault.maxRedeem(fish.address) == assets
     assert vault.maxRedeem(bunny.address) == 0
 
     new_limit = assets * 2
-    limit_module.set_default_withdraw_limit(new_limit, sender=gov)
+    hook.set_default_withdraw_limit(new_limit, sender=gov)
 
     # Doesn't change
     assert vault.maxRedeem(fish.address) == assets
@@ -812,7 +812,7 @@ def test_max_redeem__with_withdraw_limit_module(
 
     # Set limit below the balance
     new_limit = assets // 2
-    limit_module.set_default_withdraw_limit(new_limit, sender=gov)
+    hook.set_default_withdraw_limit(new_limit, sender=gov)
 
     assert vault.maxRedeem(fish.address) == new_limit
     assert vault.maxRedeem(fish.address, 23, [vault]) == new_limit
@@ -820,7 +820,7 @@ def test_max_redeem__with_withdraw_limit_module(
 
 
 def test_deposit__with_max_uint(
-    asset, fish, fish_amount, gov, create_vault, deploy_limit_module, user_deposit
+    asset, fish, fish_amount, gov, create_vault, deploy_hook, user_deposit
 ):
     vault = create_vault(asset)
     assets = fish_amount
@@ -842,20 +842,20 @@ def test_deposit__with_max_uint(
     assert asset.balanceOf(vault.address) == assets
 
 
-def test_deposit__with_deposit_limit_module(
-    asset, fish, fish_amount, gov, create_vault, deploy_limit_module, user_deposit
+def test_deposit__with_deposit_hook(
+    asset, fish, fish_amount, gov, create_vault, deploy_hook, user_deposit
 ):
     vault = create_vault(asset, deposit_limit=0)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
     assets = fish_amount
 
     asset.approve(vault.address, assets, sender=fish)
 
     vault.set_deposit_limit(MAX_INT, sender=gov)
-    vault.set_deposit_limit_module(limit_module, sender=gov)
+    vault.set_deposit_hook(hook, sender=gov)
 
     # If not on a whitelist it reverts.
-    limit_module.set_enforce_whitelist(True, sender=gov)
+    hook.set_enforce_whitelist(True, sender=gov)
 
     assert vault.maxDeposit(fish.address) == 0
 
@@ -863,7 +863,7 @@ def test_deposit__with_deposit_limit_module(
         vault.deposit(assets, fish.address, sender=fish)
 
     # If whitelisted it now works
-    limit_module.set_whitelist(fish.address, sender=gov)
+    hook.set_whitelist(fish.address, sender=gov)
     assert vault.maxDeposit(fish.address) == MAX_INT
 
     # Should go through now
@@ -877,22 +877,27 @@ def test_deposit__with_deposit_limit_module(
     assert event.sender == fish
     assert vault.balanceOf(fish.address) == assets
     assert asset.balanceOf(vault.address) == assets
+    assert hook.post_deposit_count() == 1
+    assert hook.last_deposit_sender() == fish.address
+    assert hook.last_deposit_receiver() == fish.address
+    assert hook.last_deposit_assets() == assets
+    assert hook.last_deposit_shares() == assets
 
 
-def test_mint__with_deposit_limit_module(
-    asset, fish, fish_amount, gov, create_vault, deploy_limit_module, user_deposit
+def test_mint__with_deposit_hook(
+    asset, fish, fish_amount, gov, create_vault, deploy_hook, user_deposit
 ):
     vault = create_vault(asset, deposit_limit=0)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
     assets = fish_amount
 
     asset.approve(vault.address, assets, sender=fish)
 
     vault.set_deposit_limit(MAX_INT, sender=gov)
-    vault.set_deposit_limit_module(limit_module, sender=gov)
+    vault.set_deposit_hook(hook, sender=gov)
 
     # If not on a whitelist it reverts.
-    limit_module.set_enforce_whitelist(True, sender=gov)
+    hook.set_enforce_whitelist(True, sender=gov)
 
     assert vault.maxMint(fish.address) == 0
 
@@ -900,7 +905,7 @@ def test_mint__with_deposit_limit_module(
         vault.mint(assets, fish.address, sender=fish)
 
     # If whitelisted it now works
-    limit_module.set_whitelist(fish.address, sender=gov)
+    hook.set_whitelist(fish.address, sender=gov)
     assert vault.maxMint(fish.address) == MAX_INT
 
     # Should go through now
@@ -914,23 +919,51 @@ def test_mint__with_deposit_limit_module(
     assert event.sender == fish
     assert vault.balanceOf(fish.address) == assets
     assert asset.balanceOf(vault.address) == assets
+    assert hook.post_deposit_count() == 1
+    assert hook.last_deposit_sender() == fish.address
+    assert hook.last_deposit_receiver() == fish.address
+    assert hook.last_deposit_assets() == assets
+    assert hook.last_deposit_shares() == assets
 
 
-def test_withdraw__with_withdraw_limit_module(
-    asset, fish, fish_amount, gov, create_vault, deploy_limit_module, user_deposit
+def test_deposit__post_deposit_hook_reverts(
+    asset, fish, fish_amount, gov, create_vault, deploy_hook
 ):
     vault = create_vault(asset)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
+    assets = fish_amount
+
+    asset.approve(vault.address, assets, sender=fish)
+    vault.set_deposit_hook(hook, sender=gov)
+    hook.set_revert_post_deposit(True, sender=gov)
+
+    fish_balance_before = asset.balanceOf(fish)
+    vault_balance_before = asset.balanceOf(vault)
+
+    with ape.reverts("post deposit revert"):
+        vault.deposit(assets, fish.address, sender=fish)
+
+    assert hook.post_deposit_count() == 0
+    assert vault.balanceOf(fish.address) == 0
+    assert asset.balanceOf(fish) == fish_balance_before
+    assert asset.balanceOf(vault) == vault_balance_before
+
+
+def test_withdraw__with_withdraw_hook(
+    asset, fish, fish_amount, gov, create_vault, deploy_hook, user_deposit
+):
+    vault = create_vault(asset)
+    hook = deploy_hook()
     assets = fish_amount
 
     user_deposit(fish, vault, asset, assets)
 
-    vault.set_withdraw_limit_module(limit_module, sender=gov)
+    vault.set_withdraw_hook(hook, sender=gov)
 
     assert vault.maxWithdraw(fish.address) == assets
 
     new_limit = 0
-    limit_module.set_default_withdraw_limit(new_limit, sender=gov)
+    hook.set_default_withdraw_limit(new_limit, sender=gov)
 
     assert vault.maxWithdraw(fish.address) == 0
 
@@ -938,7 +971,7 @@ def test_withdraw__with_withdraw_limit_module(
         vault.withdraw(assets, fish.address, fish.address, sender=fish)
 
     new_limit = assets
-    limit_module.set_default_withdraw_limit(new_limit, sender=gov)
+    hook.set_default_withdraw_limit(new_limit, sender=gov)
 
     assert vault.maxWithdraw(fish.address) == assets
 
@@ -954,23 +987,52 @@ def test_withdraw__with_withdraw_limit_module(
     assert vault.balanceOf(fish.address) == 0
     assert asset.balanceOf(vault.address) == 0
     assert asset.balanceOf(fish.address) == assets
+    assert hook.post_withdraw_count() == 1
+    assert hook.last_withdraw_sender() == fish.address
+    assert hook.last_withdraw_receiver() == fish.address
+    assert hook.last_withdraw_owner() == fish.address
+    assert hook.last_withdraw_assets() == assets
+    assert hook.last_withdraw_shares() == assets
 
 
-def test_redeem__with_withdraw_limit_module(
-    asset, fish, fish_amount, gov, create_vault, deploy_limit_module, user_deposit
+def test_withdraw__post_withdraw_hook_reverts(
+    asset, fish, fish_amount, gov, create_vault, deploy_hook, user_deposit
 ):
     vault = create_vault(asset)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
+    assets = fish_amount
+
+    user_deposit(fish, vault, asset, assets)
+    vault.set_withdraw_hook(hook, sender=gov)
+    hook.set_revert_post_withdraw(True, sender=gov)
+
+    fish_balance_before = asset.balanceOf(fish)
+    vault_balance_before = asset.balanceOf(vault)
+
+    with ape.reverts("post withdraw revert"):
+        vault.withdraw(assets, fish.address, fish.address, sender=fish)
+
+    assert hook.post_withdraw_count() == 0
+    assert vault.balanceOf(fish.address) == assets
+    assert asset.balanceOf(fish) == fish_balance_before
+    assert asset.balanceOf(vault) == vault_balance_before
+
+
+def test_redeem__with_withdraw_hook(
+    asset, fish, fish_amount, gov, create_vault, deploy_hook, user_deposit
+):
+    vault = create_vault(asset)
+    hook = deploy_hook()
     assets = fish_amount
 
     user_deposit(fish, vault, asset, assets)
 
-    vault.set_withdraw_limit_module(limit_module, sender=gov)
+    vault.set_withdraw_hook(hook, sender=gov)
 
     assert vault.maxRedeem(fish.address) == assets
 
     new_limit = 0
-    limit_module.set_default_withdraw_limit(new_limit, sender=gov)
+    hook.set_default_withdraw_limit(new_limit, sender=gov)
 
     assert vault.maxRedeem(fish.address) == 0
 
@@ -978,7 +1040,7 @@ def test_redeem__with_withdraw_limit_module(
         vault.redeem(assets, fish.address, fish.address, sender=fish)
 
     new_limit = assets
-    limit_module.set_default_withdraw_limit(new_limit, sender=gov)
+    hook.set_default_withdraw_limit(new_limit, sender=gov)
 
     assert vault.maxRedeem(fish.address) == assets
 
@@ -994,9 +1056,15 @@ def test_redeem__with_withdraw_limit_module(
     assert vault.balanceOf(fish.address) == 0
     assert asset.balanceOf(vault.address) == 0
     assert asset.balanceOf(fish.address) == assets
+    assert hook.post_withdraw_count() == 1
+    assert hook.last_withdraw_sender() == fish.address
+    assert hook.last_withdraw_receiver() == fish.address
+    assert hook.last_withdraw_owner() == fish.address
+    assert hook.last_withdraw_assets() == assets
+    assert hook.last_withdraw_shares() == assets
 
 
-def test_redeem__with_withdraw_limit_module_uses_default_queue(
+def test_redeem__with_withdraw_hook_uses_default_queue(
     asset,
     fish,
     fish_amount,
@@ -1005,11 +1073,11 @@ def test_redeem__with_withdraw_limit_module_uses_default_queue(
     create_strategy,
     add_debt_to_strategy,
     add_strategy_to_vault,
-    deploy_limit_module,
+    deploy_hook,
     user_deposit,
 ):
     vault = create_vault(asset)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
     strategy = create_strategy(vault)
     assets = fish_amount
 
@@ -1017,8 +1085,8 @@ def test_redeem__with_withdraw_limit_module_uses_default_queue(
     add_strategy_to_vault(gov, strategy, vault)
     add_debt_to_strategy(gov, strategy, vault, assets)
 
-    vault.set_withdraw_limit_module(limit_module, sender=gov)
-    limit_module.set_required_withdraw_strategy(strategy.address, sender=gov)
+    vault.set_withdraw_hook(hook, sender=gov)
+    hook.set_required_withdraw_strategy(strategy.address, sender=gov)
 
     assert vault.maxRedeem(fish.address) == assets
 
@@ -1034,7 +1102,7 @@ def test_redeem__with_withdraw_limit_module_uses_default_queue(
     assert asset.balanceOf(fish.address) == assets
 
 
-def test_withdraw__with_withdraw_limit_module_uses_forced_default_queue(
+def test_withdraw__with_withdraw_hook_uses_forced_default_queue(
     asset,
     fish,
     fish_amount,
@@ -1043,11 +1111,11 @@ def test_withdraw__with_withdraw_limit_module_uses_forced_default_queue(
     create_strategy,
     add_debt_to_strategy,
     add_strategy_to_vault,
-    deploy_limit_module,
+    deploy_hook,
     user_deposit,
 ):
     vault = create_vault(asset)
-    limit_module = deploy_limit_module()
+    hook = deploy_hook()
     default_strategy = create_strategy(vault)
     custom_strategy = create_strategy(vault)
     assets = fish_amount
@@ -1057,8 +1125,8 @@ def test_withdraw__with_withdraw_limit_module_uses_forced_default_queue(
     add_strategy_to_vault(gov, custom_strategy, vault)
     add_debt_to_strategy(gov, default_strategy, vault, assets)
 
-    vault.set_withdraw_limit_module(limit_module, sender=gov)
-    limit_module.set_required_withdraw_strategy(default_strategy.address, sender=gov)
+    vault.set_withdraw_hook(hook, sender=gov)
+    hook.set_required_withdraw_strategy(default_strategy.address, sender=gov)
     vault.set_use_default_queue(True, sender=gov)
 
     assert vault.maxWithdraw(fish.address, 0, [custom_strategy]) == assets

--- a/tests/unit/vault/test_role_base_access.py
+++ b/tests/unit/vault/test_role_base_access.py
@@ -149,7 +149,7 @@ def test_set_deposit_limit__deposit_limit_manager(gov, vault, bunny):
     assert vault.deposit_limit() == deposit_limit
 
 
-def test_set_deposit_limit_with_limit_module__reverts(gov, vault, bunny):
+def test_set_deposit_limit_with_hook__reverts(gov, vault, bunny):
     # We temporarily give bunny the role
     tx = vault.set_role(bunny.address, ROLES.DEPOSIT_LIMIT_MANAGER, sender=gov)
 
@@ -160,13 +160,13 @@ def test_set_deposit_limit_with_limit_module__reverts(gov, vault, bunny):
 
     deposit_limit = 1
 
-    vault.set_deposit_limit_module(bunny, sender=gov)
+    vault.set_deposit_hook(bunny, sender=gov)
 
-    with ape.reverts("using module"):
+    with ape.reverts("using hook"):
         vault.set_deposit_limit(deposit_limit, sender=bunny)
 
 
-def test_set_deposit_limit_with_limit_module__override(gov, vault, bunny):
+def test_set_deposit_limit_with_hook__override(gov, vault, bunny):
     # We temporarily give bunny the role
     tx = vault.set_role(bunny.address, ROLES.DEPOSIT_LIMIT_MANAGER, sender=gov)
 
@@ -176,24 +176,24 @@ def test_set_deposit_limit_with_limit_module__override(gov, vault, bunny):
     assert event[0].role == ROLES.DEPOSIT_LIMIT_MANAGER
 
     deposit_limit = 1
-    deposit_limit_module = bunny
+    deposit_hook = bunny
 
-    vault.set_deposit_limit_module(deposit_limit_module, sender=gov)
+    vault.set_deposit_hook(deposit_hook, sender=gov)
 
-    assert vault.deposit_limit_module() == deposit_limit_module
+    assert vault.deposit_hook() == deposit_hook
 
-    with ape.reverts("using module"):
+    with ape.reverts("using hook"):
         vault.set_deposit_limit(deposit_limit, sender=bunny)
 
     tx = vault.set_deposit_limit(deposit_limit, True, sender=bunny)
 
     assert vault.deposit_limit() == deposit_limit
-    assert vault.deposit_limit_module() == ZERO_ADDRESS
+    assert vault.deposit_hook() == ZERO_ADDRESS
 
-    event = list(tx.decode_logs(vault.UpdateDepositLimitModule))
+    event = list(tx.decode_logs(vault.UpdateDepositHook))
 
     assert len(event) == 1
-    assert event[0].deposit_limit_module == ZERO_ADDRESS
+    assert event[0].deposit_hook == ZERO_ADDRESS
 
     event = list(tx.decode_logs(vault.UpdateDepositLimit))
 
@@ -201,13 +201,13 @@ def test_set_deposit_limit_with_limit_module__override(gov, vault, bunny):
     assert event[0].deposit_limit == deposit_limit
 
 
-def test_set_deposit_limit_module__no_deposit_limit_manager__reverts(bunny, vault):
-    deposit_limit_module = bunny
+def test_set_deposit_hook__no_deposit_limit_manager__reverts(bunny, vault):
+    deposit_hook = bunny
     with ape.reverts("not allowed"):
-        vault.set_deposit_limit_module(deposit_limit_module, sender=bunny)
+        vault.set_deposit_hook(deposit_hook, sender=bunny)
 
 
-def test_set_deposit_limit_module__deposit_limit_manager(gov, vault, bunny):
+def test_set_deposit_hook__deposit_limit_manager(gov, vault, bunny):
     # We temporarily give bunny the role
     tx = vault.set_role(bunny.address, ROLES.DEPOSIT_LIMIT_MANAGER, sender=gov)
 
@@ -216,19 +216,19 @@ def test_set_deposit_limit_module__deposit_limit_manager(gov, vault, bunny):
     assert event[0].account == bunny.address
     assert event[0].role == ROLES.DEPOSIT_LIMIT_MANAGER
 
-    deposit_limit_module = bunny
-    assert vault.deposit_limit_module() == ZERO_ADDRESS
-    tx = vault.set_deposit_limit_module(deposit_limit_module, sender=bunny)
+    deposit_hook = bunny
+    assert vault.deposit_hook() == ZERO_ADDRESS
+    tx = vault.set_deposit_hook(deposit_hook, sender=bunny)
 
-    assert vault.deposit_limit_module() == deposit_limit_module
+    assert vault.deposit_hook() == deposit_hook
 
-    event = list(tx.decode_logs(vault.UpdateDepositLimitModule))
+    event = list(tx.decode_logs(vault.UpdateDepositHook))
 
     assert len(event) == 1
-    assert event[0].deposit_limit_module == deposit_limit_module
+    assert event[0].deposit_hook == deposit_hook
 
 
-def test_set_deposit_limit_module_with_limit__reverts(gov, vault, bunny):
+def test_set_deposit_hook_with_limit__reverts(gov, vault, bunny):
     # We temporarily give bunny the role
     tx = vault.set_role(bunny.address, ROLES.DEPOSIT_LIMIT_MANAGER, sender=gov)
 
@@ -240,10 +240,10 @@ def test_set_deposit_limit_module_with_limit__reverts(gov, vault, bunny):
     vault.set_deposit_limit(1, sender=gov)
 
     with ape.reverts("using deposit limit"):
-        vault.set_deposit_limit_module(bunny, sender=gov)
+        vault.set_deposit_hook(bunny, sender=gov)
 
 
-def test_set_deposit_limit_module_with_limit__override(gov, vault, bunny):
+def test_set_deposit_hook_with_limit__override(gov, vault, bunny):
     # We temporarily give bunny the role
     tx = vault.set_role(bunny.address, ROLES.DEPOSIT_LIMIT_MANAGER, sender=gov)
 
@@ -254,19 +254,19 @@ def test_set_deposit_limit_module_with_limit__override(gov, vault, bunny):
 
     vault.set_deposit_limit(1, sender=gov)
 
-    deposit_limit_module = bunny
+    deposit_hook = bunny
     with ape.reverts("using deposit limit"):
-        vault.set_deposit_limit_module(deposit_limit_module, sender=gov)
+        vault.set_deposit_hook(deposit_hook, sender=gov)
 
-    tx = vault.set_deposit_limit_module(deposit_limit_module, True, sender=gov)
+    tx = vault.set_deposit_hook(deposit_hook, True, sender=gov)
 
     assert vault.deposit_limit() == MAX_INT
-    assert vault.deposit_limit_module() == deposit_limit_module
+    assert vault.deposit_hook() == deposit_hook
 
-    event = list(tx.decode_logs(vault.UpdateDepositLimitModule))
+    event = list(tx.decode_logs(vault.UpdateDepositHook))
 
     assert len(event) == 1
-    assert event[0].deposit_limit_module == deposit_limit_module
+    assert event[0].deposit_hook == deposit_hook
 
     event = list(tx.decode_logs(vault.UpdateDepositLimit))
 
@@ -274,13 +274,13 @@ def test_set_deposit_limit_module_with_limit__override(gov, vault, bunny):
     assert event[0].deposit_limit == MAX_INT
 
 
-def test_set_withdraw_limit_module__no_withdraw_limit_manager__reverts(bunny, vault):
-    withdraw_limit_module = bunny
+def test_set_withdraw_hook__no_withdraw_limit_manager__reverts(bunny, vault):
+    withdraw_hook = bunny
     with ape.reverts("not allowed"):
-        vault.set_withdraw_limit_module(withdraw_limit_module, sender=bunny)
+        vault.set_withdraw_hook(withdraw_hook, sender=bunny)
 
 
-def test_set_withdraw_limit_module__withdraw_limit_manager(gov, vault, bunny):
+def test_set_withdraw_hook__withdraw_limit_manager(gov, vault, bunny):
     # We temporarily give bunny the role
     tx = vault.set_role(bunny.address, ROLES.WITHDRAW_LIMIT_MANAGER, sender=gov)
 
@@ -289,16 +289,16 @@ def test_set_withdraw_limit_module__withdraw_limit_manager(gov, vault, bunny):
     assert event[0].account == bunny.address
     assert event[0].role == ROLES.WITHDRAW_LIMIT_MANAGER
 
-    withdraw_limit_module = bunny
-    assert vault.withdraw_limit_module() == ZERO_ADDRESS
-    tx = vault.set_withdraw_limit_module(withdraw_limit_module, sender=bunny)
+    withdraw_hook = bunny
+    assert vault.withdraw_hook() == ZERO_ADDRESS
+    tx = vault.set_withdraw_hook(withdraw_hook, sender=bunny)
 
-    assert vault.withdraw_limit_module() == withdraw_limit_module
+    assert vault.withdraw_hook() == withdraw_hook
 
-    event = list(tx.decode_logs(vault.UpdateWithdrawLimitModule))
+    event = list(tx.decode_logs(vault.UpdateWithdrawHook))
 
     assert len(event) == 1
-    assert event[0].withdraw_limit_module == withdraw_limit_module
+    assert event[0].withdraw_hook == withdraw_hook
 
 
 # DEBT_PURCHASER


### PR DESCRIPTION
## Summary
- rename deposit/withdraw limit modules to deposit/withdraw hooks
- keep existing limit view behavior and add post-deposit/post-withdraw callbacks
- update hook mock, docs, and focused vault tests
- point Ape tokenized-strategy dependency at v3.0.4 so tests can install dependencies

## Tests
- forge build
- forge test --match-path foundry_tests/tests/Invariants.t.sol
- .venv/bin/pytest tests/unit/vault/test_erc4626.py tests/unit/vault/test_role_base_access.py tests/unit/vault/test_emergency_shutdown.py