### PR TITLE
feat: add vault transfer hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yearn V3 Vaults
 
-This repository contains the smart contracts for Yearn's V3 vault implementation.
+This repository contains the smart contracts for Yearn's V3 vault implementation. The current vault API version is `3.1.1`.
 
 [VaultFactory.vy](contracts/VaultFactory.vy) - The base factory that all vaults will be deployed from and used to configure protocol fees
 
@@ -81,13 +81,7 @@ Deployments on new chains can be done permissionlessly by anyone using the inclu
 ape run scripts/deploy.py --network YOUR_RPC_URL
 ```
 
-The script currently uses raw salt `0x0000000000000000000000000000000000000000000000000000000000004b62`. The deterministic deployer hashes this raw salt before CREATE2. With the current bytecode and constructor args, the expected addresses are:
-
 ```
-Vault original: 0xdD3FA86409658d207A9BE0141eE560C8db557824
-Vault Factory:  0x310aC28ACF5E514abDbFF9Ab25e21f1bfe22bcAC
-```
-
 To dry run against a mainnet fork, start Hardhat in one terminal:
 
 ```

--- a/TECH_SPEC.md
+++ b/TECH_SPEC.md
@@ -8,7 +8,7 @@
 - Vault: ERC4626 compliant Smart contract that receives Assets from Depositors to then distribute them among the different Strategies added to the vault, managing accounting and Assets distribution. 
 - Role: the different flags an Account can have in the Vault so that the Account can do certain specific actions. Can be fulfilled by a smart contract or an EOA.
 - Accountant: smart contract that receives P&L reporting and returns shares and refunds to the strategy
-- Hooks: Add on smart contracts that can control vault deposit and withdraw limits dynamically and receive post-deposit or post-withdraw callbacks.
+- Hooks: Add-on smart contracts that can control vault deposit and withdraw limits dynamically, receive post-deposit or post-withdraw callbacks, or observe and reject vault share transfers.
 
 # VaultV3 Specification
 The Vault code has been designed as an non-opinionated system to distribute funds of depositors into different opportunities (aka Strategies) and manage accounting in a robust way. That's all.
@@ -31,6 +31,7 @@ Example periphery contracts:
 - Debt Allocator: a smart contract that optimizes between multiple strategies based on the optimal return. (see [DebAllocators](https://github.com/yearn/vault-periphery/tree/master/contracts/debtAllocators))
 - Safety Staking Module: a smart contract that allows players to sponsor specific strategies (so that they are added to the vault) by staking their YFI, making money if they do well and losing money if they don't.
 - Deposit Hook: Will dynamically adjust the deposit limit based on the depositor and arbitrary conditions, and can react after deposits.
+- Transfer Hook: Observes post-transfer state and can accept or reject vault share transfers.
 - ...
 ```
 ## Deployment
@@ -70,6 +71,12 @@ Vault shares are ERC20 transferable yield-bearing tokens.
 
 They are ERC4626 compliant. Please read [ERC4626 compliance](https://hackmd.io/cOFvpyR-SxWArfthhLJb5g#ERC4626-compliance) to understand the implications. 
 
+An optional transfer hook can observe and reject successful `transfer` and `transferFrom` calls after balances, finite allowances, and the `Transfer` event have been updated. A hook revert rolls back the full transfer. The callback receives the caller, sender, receiver, and share amount; for `transferFrom`, caller is the spender. Successful zero-share and self-transfers also invoke the hook. A zero-value `transferFrom` requires no allowance, so an attacker can choose the caller, sender, and any valid receiver (nonzero and not the vault). Hook accounting must tolerate free callback spam and must not treat a zero-share callback as evidence of sender authorization or economic activity.
+
+All share transfers use the vault's shared reentrancy lock, even when no transfer hook is configured. Every transfer therefore pays for the shared-lock operations and a normally cold load of the `transfer_hook` storage slot. Against API 3.1.0, isolated receipt benchmarks measured an extra 4,478 gas for `transfer` and 4,466 gas for `transferFrom` with no hook configured; a configured no-op hook adds another 2,991 gas. A reverting hook consumed 64,306 gas for `transfer` and 72,073 gas for finite-allowance `transferFrom`, with the full state change rolled back. This universal gas overhead also comes with a composability regression: transfers cannot execute inside the same vault's deposit, withdrawal, reporting, or debt-management flows. A transfer hook runs while that lock is held. It may read post-transfer state, interact with other systems, or revert, but it cannot call locked functions on the same vault. It is an observer and policy callback, not an auto-staking or same-vault rebalancing engine.
+
+A transfer hook alone is not a complete transfer restriction or compliance boundary. `deposit` and `mint` can issue shares directly to a receiver, while `withdraw` and `redeem` can burn one owner's shares and send assets to another receiver. A complete allowlist must compose the transfer hook with deposit and withdraw hooks.
+
 ### Accounting
 The vault will evaluate profit and losses from the strategies. 
 
@@ -102,7 +109,7 @@ Issue of new shares due to fees will also unlock profit so that PPS does not go 
 Both of this offsets will prevent front running (as the profit was already earned and was not distributed yet)
 
 ## Vault Management
-Vault management is split into function specific roles. Each permissioned function has its own corresponding Role.
+Vault management is split into capability roles. Each permissioned function is assigned a role, and closely related functions may share one.
 
 This means roles can be combined all to one address, each distributed to separate addresses or any combination in between
 
@@ -119,7 +126,7 @@ These are:
 - DEBT_MANAGER: role that adds and removes debt from strategies
 - MAX_DEBT_MANAGER: role that can set the max debt for a strategy
 - DEPOSIT_LIMIT_MANAGER: role that sets deposit limit or deposit hook for the vault
-- WITHDRAW_LIMIT_MANAGER: role that sets the withdraw hook for the vault.
+- WITHDRAW_LIMIT_MANAGER: role that sets the withdraw and transfer hooks for the vault.
 - MINIMUM_IDLE_MANAGER: role that sets the minimum total idle the vault should keep
 - PROFIT_UNLOCK_MANAGER: role that sets the profit_max_unlock_time
 - DEBT_PURCHASER # can purchase bad debt from the vault
@@ -151,7 +158,11 @@ A deposit_hook can be set by the DEPOSIT_LIMIT_MANAGER
 
 A withdraw_hook can be set by the WITHDRAW_LIMIT_MANAGER
 
+A transfer_hook can be set by the WITHDRAW_LIMIT_MANAGER
+
 These contracts are not needed for the vault to function but are optional add ons for optimal use.
+
+The transfer hook remains active and mutable while the vault is paused or shut down because share transfers remain live. The setter does not validate hook bytecode or interface support. `WITHDRAW_LIMIT_MANAGER` controls both the withdraw and transfer hooks; every existing holder of that role therefore gains authority to brick share transfers by installing an EOA or reverting contract. The emergency manager has no automatic override; recovery requires a current withdraw limit manager or the role manager granting that permission to a clean account.
 
 #### Reporting profits
 The REPORTING_MANAGER is in charge of calling process_report() for each strategy in the vault according to its own timeline
@@ -196,6 +207,11 @@ The deposit_limit will have to be set to MAX_UINT256 in order to set a deposit_h
 The WITHDRAW_LIMIT_MANAGER is in charge of setting the withdraw_hook for the vault
 
 The vaults default withdraw limit is calculated based on the liquidity of its strategies. Setting a withdraw hook will override this functionality.
+
+#### Setting the transfer hook
+The WITHDRAW_LIMIT_MANAGER is in charge of setting both the withdraw_hook and transfer_hook for the vault.
+
+The transfer hook runs after successful `transfer` and `transferFrom` state changes and can revert to reject them. It does not run for share minting or burning during deposits, mints, withdrawals, redeems, fee issuance, or profit locking.
 
 #### Setting minimum idle funds
 The MINIMUM_IDLE_MANAGER can specify how many funds the vault should try to have reserved to serve withdrawal requests

--- a/contracts/VaultFactory.vy
+++ b/contracts/VaultFactory.vy
@@ -70,7 +70,7 @@ event UpdatePendingGovernance:
 
 
 # Identifier for this version of the vault.
-API_VERSION: constant(String[28]) = "3.1.0"
+API_VERSION: constant(String[28]) = "3.1.1"
 
 # The max amount the protocol fee can be set to.
 MAX_FEE_BPS: constant(uint16) = 5_000 # 50%

--- a/contracts/VaultV3.vy
+++ b/contracts/VaultV3.vy
@@ -61,6 +61,9 @@ interface IWithdrawHook:
     def available_withdraw_limit(owner: address, max_loss: uint256, strategies: DynArray[address, MAX_QUEUE]) -> uint256: view
     def post_withdraw(sender: address, receiver: address, owner: address, assets: uint256, shares: uint256): nonpayable
 
+interface ITransferHook:
+    def post_transfer(caller: address, sender: address, receiver: address, shares: uint256): nonpayable
+
 interface IFactory:
     def protocol_fee_config() -> (uint16, address): view
 
@@ -131,6 +134,9 @@ event UpdateDepositHook:
 event UpdateWithdrawHook:
     withdraw_hook: indexed(address)
 
+event UpdateTransferHook:
+    transfer_hook: indexed(address)
+
 event UpdateDefaultQueue:
     new_default_queue: DynArray[address, MAX_QUEUE]
 
@@ -183,11 +189,11 @@ MAX_BPS: constant(uint256) = 10_000
 # Extended for profit locking calculations.
 MAX_BPS_EXTENDED: constant(uint256) = 1_000_000_000_000
 # The version of this vault.
-API_VERSION: constant(String[28]) = "3.1.0"
+API_VERSION: constant(String[28]) = "3.1.1"
 
 # ENUMS #
-# Each permissioned function has its own Role.
-# Roles can be combined in any combination or all kept separate.
+# Permissioned functions are assigned a Role.
+# Roles can govern closely related functions and be combined in any combination.
 # Follows python Enum patterns so the first Enum == 1 and doubles each time.
 enum Roles:
     ADD_STRATEGY_MANAGER # Can add strategies to the vault.
@@ -199,7 +205,7 @@ enum Roles:
     DEBT_MANAGER # Adds and removes debt from strategies.
     MAX_DEBT_MANAGER # Can set the max debt for a strategy.
     DEPOSIT_LIMIT_MANAGER # Sets deposit limit and deposit hook for the vault.
-    WITHDRAW_LIMIT_MANAGER # Sets the withdraw hook.
+    WITHDRAW_LIMIT_MANAGER # Sets the withdraw and transfer hooks.
     MINIMUM_IDLE_MANAGER # Sets the minimum total idle the vault should keep.
     PROFIT_UNLOCK_MANAGER # Sets the profit_max_unlock_time.
     DEBT_PURCHASER # Can purchase bad debt from the vault.
@@ -253,6 +259,8 @@ accountant: public(address)
 deposit_hook: public(address)
 # Contract to control the withdraw limit and receive post-withdraw callbacks.
 withdraw_hook: public(address)
+# Contract to receive post-transfer callbacks.
+transfer_hook: public(address)
 
 ### ROLES ###
 # HashMap mapping addresses to their roles
@@ -349,6 +357,10 @@ def _transfer(sender: address, receiver: address, amount: uint256):
     self.balance_of[sender] = unsafe_sub(sender_balance, amount)
     self.balance_of[receiver] = unsafe_add(self.balance_of[receiver], amount)
     log Transfer(sender, receiver, amount)
+
+    transfer_hook: address = self.transfer_hook
+    if transfer_hook != empty(address):
+        ITransferHook(transfer_hook).post_transfer(msg.sender, sender, receiver, amount)
 
 @internal
 def _transfer_from(sender: address, receiver: address, amount: uint256) -> bool:
@@ -1497,6 +1509,20 @@ def set_withdraw_hook(withdraw_hook: address):
     log UpdateWithdrawHook(withdraw_hook)
 
 @external
+def set_transfer_hook(transfer_hook: address):
+    """
+    @notice Set a contract to receive post-transfer callbacks.
+    @dev The callback executes while the vault's shared nonreentrant lock is held.
+        Setting this to the zero address disables transfer callbacks.
+    @param transfer_hook Address of the hook.
+    """
+    self._enforce_role(msg.sender, Roles.WITHDRAW_LIMIT_MANAGER)
+
+    self.transfer_hook = transfer_hook
+
+    log UpdateTransferHook(transfer_hook)
+
+@external
 def set_minimum_total_idle(minimum_total_idle: uint256):
     """
     @notice Set the new minimum total idle.
@@ -1923,6 +1949,7 @@ def approve(spender: address, amount: uint256) -> bool:
     return self._approve(msg.sender, spender, amount)
 
 @external
+@nonreentrant("lock")
 def transfer(receiver: address, amount: uint256) -> bool:
     """
     @notice Transfer shares to a receiver.
@@ -1935,6 +1962,7 @@ def transfer(receiver: address, amount: uint256) -> bool:
     return True
 
 @external
+@nonreentrant("lock")
 def transferFrom(sender: address, receiver: address, amount: uint256) -> bool:
     """
     @notice Transfer shares from a sender to a receiver.

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -32,6 +32,7 @@ interface IVault is IERC4626 {
     event UpdateAccountant(address indexed accountant);
     event UpdateDepositHook(address indexed deposit_hook);
     event UpdateWithdrawHook(address indexed withdraw_hook);
+    event UpdateTransferHook(address indexed transfer_hook);
     event UpdateDefaultQueue(address[] new_default_queue);
     event UpdateUseDefaultQueue(bool use_default_queue);
     event UpdatedMaxDebtForStrategy(
@@ -71,6 +72,8 @@ interface IVault is IERC4626 {
     function deposit_hook() external view returns (address);
 
     function withdraw_hook() external view returns (address);
+
+    function transfer_hook() external view returns (address);
 
     function accountant() external view returns (address);
 
@@ -121,6 +124,8 @@ interface IVault is IERC4626 {
     ) external;
 
     function set_withdraw_hook(address new_withdraw_hook) external;
+
+    function set_transfer_hook(address new_transfer_hook) external;
 
     function set_minimum_total_idle(uint256 minimum_total_idle) external;
 

--- a/contracts/test/mocks/periphery/HookModule.vy
+++ b/contracts/test/mocks/periphery/HookModule.vy
@@ -3,6 +3,17 @@
 
 interface IVault:
     def totalAssets() -> uint256: view
+    def balanceOf(owner: address) -> uint256: view
+    def allowance(owner: address, spender: address) -> uint256: view
+    def transfer(receiver: address, amount: uint256) -> bool: nonpayable
+    def transferFrom(sender: address, receiver: address, amount: uint256) -> bool: nonpayable
+    def redeem(shares: uint256, receiver: address, owner: address) -> uint256: nonpayable
+
+event TransferHookCalled:
+    caller: indexed(address)
+    sender: indexed(address)
+    receiver: indexed(address)
+    shares: uint256
 
 enforce_whitelist: public(bool)
 
@@ -36,9 +47,38 @@ last_withdraw_shares: public(uint256)
 
 post_withdraw_count: public(uint256)
 
+last_transfer_caller: public(address)
+
+last_transfer_sender: public(address)
+
+last_transfer_receiver: public(address)
+
+last_transfer_shares: public(uint256)
+
+last_transfer_sender_balance: public(uint256)
+
+last_transfer_receiver_balance: public(uint256)
+
+last_transfer_allowance: public(uint256)
+
+post_transfer_count: public(uint256)
+
 revert_post_deposit: public(bool)
 
 revert_post_withdraw: public(bool)
+
+revert_post_transfer: public(bool)
+
+# 0 = disabled, 1 = transfer, 2 = transferFrom, 3 = redeem.
+post_transfer_reentry_mode: public(uint256)
+
+reentry_sender: public(address)
+
+reentry_receiver: public(address)
+
+reentry_amount: public(uint256)
+
+reenter_post_deposit: public(bool)
 
 @external
 def __init__(
@@ -83,6 +123,10 @@ def post_deposit(sender: address, receiver: address, assets: uint256, shares: ui
     self.last_deposit_shares = shares
     self.post_deposit_count += 1
 
+    if self.reenter_post_deposit:
+        success: bool = IVault(msg.sender).transfer(self.reentry_receiver, self.reentry_amount)
+        assert success
+
 @external
 def post_withdraw(sender: address, receiver: address, owner: address, assets: uint256, shares: uint256):
     assert not self.revert_post_withdraw, "post withdraw revert"
@@ -93,6 +137,39 @@ def post_withdraw(sender: address, receiver: address, owner: address, assets: ui
     self.last_withdraw_assets = assets
     self.last_withdraw_shares = shares
     self.post_withdraw_count += 1
+
+@external
+def post_transfer(caller: address, sender: address, receiver: address, shares: uint256):
+    assert not self.revert_post_transfer, "post transfer revert"
+
+    self.last_transfer_caller = caller
+    self.last_transfer_sender = sender
+    self.last_transfer_receiver = receiver
+    self.last_transfer_shares = shares
+    self.last_transfer_sender_balance = IVault(msg.sender).balanceOf(sender)
+    self.last_transfer_receiver_balance = IVault(msg.sender).balanceOf(receiver)
+    self.last_transfer_allowance = IVault(msg.sender).allowance(sender, caller)
+    self.post_transfer_count += 1
+
+    log TransferHookCalled(caller, sender, receiver, shares)
+
+    reentry_mode: uint256 = self.post_transfer_reentry_mode
+    # Make every attempt one-shot. If the nested call succeeds without a lock, its own
+    # transfer callback must not recurse until gas exhaustion and fake a lock failure.
+    self.post_transfer_reentry_mode = 0
+    if reentry_mode == 1:
+        success: bool = IVault(msg.sender).transfer(self.reentry_receiver, self.reentry_amount)
+        assert success
+    elif reentry_mode == 2:
+        success: bool = IVault(msg.sender).transferFrom(
+            self.reentry_sender,
+            self.reentry_receiver,
+            self.reentry_amount,
+        )
+        assert success
+    elif reentry_mode == 3:
+        redeemed_assets: uint256 = IVault(msg.sender).redeem(1, self, self)
+        assert redeemed_assets > 0
 
 @external
 def set_whitelist(list: address):
@@ -121,3 +198,21 @@ def set_revert_post_deposit(should_revert: bool):
 @external
 def set_revert_post_withdraw(should_revert: bool):
     self.revert_post_withdraw = should_revert
+
+@external
+def set_revert_post_transfer(should_revert: bool):
+    self.revert_post_transfer = should_revert
+
+@external
+def set_post_transfer_reentry(mode: uint256, sender: address, receiver: address, amount: uint256):
+    assert mode <= 3
+    self.post_transfer_reentry_mode = mode
+    self.reentry_sender = sender
+    self.reentry_receiver = receiver
+    self.reentry_amount = amount
+
+@external
+def set_reenter_post_deposit(should_reenter: bool, receiver: address, amount: uint256):
+    self.reenter_post_deposit = should_reenter
+    self.reentry_receiver = receiver
+    self.reentry_amount = amount

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -50,7 +50,7 @@ def deploy_original_and_factory():
     init_gov = "0x6f3cBE2ab3483EC4BA7B672fbdCa0E9B33F88db8"
 
     factory_constructor = vault_factory.constructor.encode_input(
-        "Yearn v3.1.0 Vault Factory",
+        "Yearn v3.1.1 Vault Factory",
         original_address,
         init_gov,
     )

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -20,7 +20,7 @@ def deploy_original_and_factory():
 
     # The deterministic deployer hashes this raw salt before CREATE2.
     salt = HexBytes(
-        "0x0000000000000000000000000000000000000000000000000000000000004b62"
+        "0x000000000000000000000000000000000000000000000000000000000000235b"
     )
 
     print("Init balance:", deployer.balance / 1e18)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -409,9 +409,10 @@ def sign_vault_permit(chain):
         allowance: int = MAX_INT,
         deadline: int = 0,
         override_nonce=None,
+        override_version=None,
     ):
         name = "Yearn Vault"
-        version = vault.apiVersion()
+        version = override_version or vault.apiVersion()
         if override_nonce:
             nonce = override_nonce
         else:

--- a/tests/unit/vault/test_transfer_hook.py
+++ b/tests/unit/vault/test_transfer_hook.py
@@ -1,0 +1,637 @@
+import ape
+import pytest
+from ape import chain
+from eth_account import Account
+
+from utils.constants import MAX_INT, ROLES, ZERO_ADDRESS
+
+
+def _vault_with_shares_and_hook(
+    asset,
+    create_vault,
+    deploy_hook,
+    user_deposit,
+    gov,
+    owner,
+    amount,
+):
+    vault = create_vault(asset)
+    user_deposit(owner, vault, asset, amount)
+    hook = deploy_hook()
+    vault.set_transfer_hook(hook.address, sender=gov)
+    return vault, hook
+
+
+def _assert_transfer_observation(
+    hook,
+    caller,
+    sender,
+    receiver,
+    shares,
+    sender_balance,
+    receiver_balance,
+    allowance,
+    count=1,
+):
+    assert hook.last_transfer_caller() == caller.address
+    assert hook.last_transfer_sender() == sender.address
+    assert hook.last_transfer_receiver() == receiver.address
+    assert hook.last_transfer_shares() == shares
+    assert hook.last_transfer_sender_balance() == sender_balance
+    assert hook.last_transfer_receiver_balance() == receiver_balance
+    assert hook.last_transfer_allowance() == allowance
+    assert hook.post_transfer_count() == count
+
+
+def test_transfer_hook_reuses_withdraw_role_and_default_governance_role(
+    asset, create_vault, vault_factory, gov
+):
+    vault = create_vault(asset)
+
+    assert ROLES.WITHDRAW_LIMIT_MANAGER == 512
+    assert ROLES.ALL == 16383
+    assert vault.roles(gov.address) == ROLES.ALL
+    assert ROLES.WITHDRAW_LIMIT_MANAGER in ROLES(vault.roles(gov.address))
+    assert vault.apiVersion() == "3.1.1"
+    assert vault_factory.apiVersion() == "3.1.1"
+
+
+def test_set_transfer_hook_acl_event_replace_and_clear(
+    asset, create_vault, deploy_hook, gov, bunny
+):
+    vault = create_vault(asset)
+    first_hook = deploy_hook()
+    second_hook = deploy_hook()
+
+    assert vault.transfer_hook() == ZERO_ADDRESS
+
+    with ape.reverts("not allowed"):
+        vault.set_transfer_hook(first_hook.address, sender=bunny)
+
+    vault.set_role(bunny.address, ROLES.DEPOSIT_LIMIT_MANAGER, sender=gov)
+    with ape.reverts("not allowed"):
+        vault.set_transfer_hook(first_hook.address, sender=bunny)
+
+    vault.set_role(bunny.address, ROLES.WITHDRAW_LIMIT_MANAGER, sender=gov)
+
+    for new_hook in (first_hook.address, second_hook.address, ZERO_ADDRESS):
+        tx = vault.set_transfer_hook(new_hook, sender=bunny)
+        events = list(tx.decode_logs(vault.UpdateTransferHook))
+
+        assert len(events) == 1
+        assert events[0].transfer_hook == new_hook
+        assert vault.transfer_hook() == new_hook
+
+
+def test_transfer_hook_is_mutable_and_active_while_paused(
+    asset,
+    create_vault,
+    deploy_hook,
+    user_deposit,
+    gov,
+    fish,
+    bunny,
+    doggie,
+    fish_amount,
+):
+    amount = fish_amount // 4
+    vault = create_vault(asset)
+    user_deposit(fish, vault, asset, amount * 2)
+    first_hook = deploy_hook()
+    second_hook = deploy_hook()
+    flow_hook = deploy_hook()
+
+    vault.setPaused(True, sender=gov)
+    vault.set_transfer_hook(first_hook.address, sender=gov)
+    vault.set_deposit_hook(flow_hook.address, sender=gov)
+    vault.set_withdraw_hook(flow_hook.address, sender=gov)
+
+    with ape.reverts("exceed deposit limit"):
+        vault.deposit(amount, fish.address, sender=fish)
+    with ape.reverts("exceed deposit limit"):
+        vault.mint(amount, fish.address, sender=fish)
+    with ape.reverts("paused"):
+        vault.withdraw(amount, fish.address, fish.address, sender=fish)
+    with ape.reverts("paused"):
+        vault.redeem(amount, fish.address, fish.address, sender=fish)
+
+    assert flow_hook.post_deposit_count() == 0
+    assert flow_hook.post_withdraw_count() == 0
+
+    vault.transfer(bunny.address, amount, sender=fish)
+    assert first_hook.post_transfer_count() == 1
+
+    vault.set_transfer_hook(second_hook.address, sender=gov)
+    vault.approve(bunny.address, amount, sender=fish)
+    vault.transferFrom(fish.address, doggie.address, amount, sender=bunny)
+
+    assert first_hook.post_transfer_count() == 1
+    assert second_hook.post_transfer_count() == 1
+
+    vault.set_transfer_hook(ZERO_ADDRESS, sender=gov)
+    assert vault.transfer_hook() == ZERO_ADDRESS
+
+
+def test_transfer_hook_is_mutable_and_active_during_shutdown(
+    asset,
+    create_vault,
+    deploy_hook,
+    user_deposit,
+    gov,
+    fish,
+    bunny,
+    doggie,
+    fish_amount,
+):
+    amount = fish_amount // 3
+    vault, first_hook = _vault_with_shares_and_hook(
+        asset, create_vault, deploy_hook, user_deposit, gov, fish, amount * 2
+    )
+    second_hook = deploy_hook()
+
+    vault.set_role(bunny.address, ROLES.EMERGENCY_MANAGER, sender=gov)
+    vault.shutdown_vault(sender=bunny)
+
+    assert vault.transfer_hook() == first_hook.address
+    vault.transfer(doggie.address, amount, sender=fish)
+    assert first_hook.post_transfer_count() == 1
+
+    with ape.reverts("not allowed"):
+        vault.set_transfer_hook(ZERO_ADDRESS, sender=bunny)
+
+    vault.set_transfer_hook(second_hook.address, sender=gov)
+    assert vault.transfer_hook() == second_hook.address
+    vault.transfer(bunny.address, amount, sender=fish)
+    assert second_hook.post_transfer_count() == 1
+    vault.set_transfer_hook(ZERO_ADDRESS, sender=gov)
+    assert vault.transfer_hook() == ZERO_ADDRESS
+
+
+def test_direct_transfer_calls_hook_after_state_and_transfer_log(
+    asset,
+    create_vault,
+    deploy_hook,
+    user_deposit,
+    gov,
+    fish,
+    bunny,
+    fish_amount,
+):
+    amount = fish_amount // 3
+    vault, hook = _vault_with_shares_and_hook(
+        asset, create_vault, deploy_hook, user_deposit, gov, fish, amount * 2
+    )
+    total_supply = vault.totalSupply()
+
+    tx = vault.transfer(bunny.address, amount, sender=fish)
+
+    transfer_log = list(tx.decode_logs(vault.Transfer))[0]
+    hook_log = list(tx.decode_logs(hook.TransferHookCalled))[0]
+    assert transfer_log.log_index < hook_log.log_index
+    _assert_transfer_observation(
+        hook,
+        fish,
+        fish,
+        bunny,
+        amount,
+        amount,
+        amount,
+        0,
+    )
+    assert vault.totalSupply() == total_supply
+
+
+def test_direct_transfer_hook_revert_rolls_back_state(
+    asset,
+    create_vault,
+    deploy_hook,
+    user_deposit,
+    gov,
+    fish,
+    bunny,
+    fish_amount,
+):
+    amount = fish_amount // 2
+    vault, hook = _vault_with_shares_and_hook(
+        asset, create_vault, deploy_hook, user_deposit, gov, fish, amount
+    )
+    hook.set_revert_post_transfer(True, sender=gov)
+    total_supply = vault.totalSupply()
+
+    with ape.reverts("post transfer revert"):
+        vault.transfer(bunny.address, amount, sender=fish)
+
+    assert vault.balanceOf(fish.address) == amount
+    assert vault.balanceOf(bunny.address) == 0
+    assert vault.totalSupply() == total_supply
+    assert hook.post_transfer_count() == 0
+
+
+def test_transfer_from_calls_hook_after_finite_allowance_is_spent(
+    asset,
+    create_vault,
+    deploy_hook,
+    user_deposit,
+    gov,
+    fish,
+    bunny,
+    doggie,
+    fish_amount,
+):
+    amount = fish_amount // 3
+    allowance = amount * 2
+    vault, hook = _vault_with_shares_and_hook(
+        asset, create_vault, deploy_hook, user_deposit, gov, fish, allowance
+    )
+    vault.approve(bunny.address, allowance, sender=fish)
+
+    tx = vault.transferFrom(fish.address, doggie.address, amount, sender=bunny)
+
+    approval_log = list(tx.decode_logs(vault.Approval))[0]
+    transfer_log = list(tx.decode_logs(vault.Transfer))[0]
+    hook_log = list(tx.decode_logs(hook.TransferHookCalled))[0]
+    assert approval_log.log_index < transfer_log.log_index < hook_log.log_index
+    _assert_transfer_observation(
+        hook,
+        bunny,
+        fish,
+        doggie,
+        amount,
+        amount,
+        amount,
+        amount,
+    )
+
+
+def test_transfer_from_preserves_infinite_allowance(
+    asset,
+    create_vault,
+    deploy_hook,
+    user_deposit,
+    gov,
+    fish,
+    bunny,
+    doggie,
+    fish_amount,
+):
+    amount = fish_amount // 4
+    vault, hook = _vault_with_shares_and_hook(
+        asset, create_vault, deploy_hook, user_deposit, gov, fish, amount
+    )
+    vault.approve(bunny.address, MAX_INT, sender=fish)
+
+    tx = vault.transferFrom(fish.address, doggie.address, amount, sender=bunny)
+
+    assert list(tx.decode_logs(vault.Approval)) == []
+    assert vault.allowance(fish.address, bunny.address) == MAX_INT
+    _assert_transfer_observation(
+        hook,
+        bunny,
+        fish,
+        doggie,
+        amount,
+        0,
+        amount,
+        MAX_INT,
+    )
+
+
+def test_transfer_from_hook_revert_restores_allowance_and_balances(
+    asset,
+    create_vault,
+    deploy_hook,
+    user_deposit,
+    gov,
+    fish,
+    bunny,
+    doggie,
+    fish_amount,
+):
+    amount = fish_amount // 2
+    vault, hook = _vault_with_shares_and_hook(
+        asset, create_vault, deploy_hook, user_deposit, gov, fish, amount
+    )
+    vault.approve(bunny.address, amount, sender=fish)
+    hook.set_revert_post_transfer(True, sender=gov)
+    total_supply = vault.totalSupply()
+
+    with ape.reverts("post transfer revert"):
+        vault.transferFrom(fish.address, doggie.address, amount, sender=bunny)
+
+    assert vault.balanceOf(fish.address) == amount
+    assert vault.balanceOf(doggie.address) == 0
+    assert vault.allowance(fish.address, bunny.address) == amount
+    assert vault.totalSupply() == total_supply
+    assert hook.post_transfer_count() == 0
+
+
+def test_zero_value_transfers_call_hook(
+    asset, create_vault, deploy_hook, gov, fish, bunny, doggie
+):
+    vault = create_vault(asset)
+    hook = deploy_hook()
+    vault.set_transfer_hook(hook.address, sender=gov)
+
+    vault.transfer(doggie.address, 0, sender=fish)
+    _assert_transfer_observation(hook, fish, fish, doggie, 0, 0, 0, 0)
+
+    # A zero-value delegated transfer needs no allowance or shares. Even the nominal
+    # sender may be the zero address, so every callback address is attacker-controlled.
+    vault.transferFrom(ZERO_ADDRESS, bunny.address, 0, sender=doggie)
+    assert hook.last_transfer_caller() == doggie.address
+    assert hook.last_transfer_sender() == ZERO_ADDRESS
+    assert hook.last_transfer_receiver() == bunny.address
+    assert hook.last_transfer_shares() == 0
+    assert hook.last_transfer_allowance() == 0
+    assert hook.post_transfer_count() == 2
+
+
+def test_self_transfers_call_hook_and_preserve_balance(
+    asset,
+    create_vault,
+    deploy_hook,
+    user_deposit,
+    gov,
+    fish,
+    bunny,
+    fish_amount,
+):
+    amount = fish_amount // 4
+    balance = amount * 2
+    vault, hook = _vault_with_shares_and_hook(
+        asset, create_vault, deploy_hook, user_deposit, gov, fish, balance
+    )
+
+    vault.transfer(fish.address, amount, sender=fish)
+    _assert_transfer_observation(
+        hook, fish, fish, fish, amount, balance, balance, 0
+    )
+
+    vault.approve(bunny.address, amount, sender=fish)
+    vault.transferFrom(fish.address, fish.address, amount, sender=bunny)
+    _assert_transfer_observation(
+        hook, bunny, fish, fish, amount, balance, balance, 0, count=2
+    )
+    assert vault.balanceOf(fish.address) == balance
+    assert vault.allowance(fish.address, bunny.address) == 0
+
+
+def test_rejected_transfers_never_call_hook(
+    asset,
+    create_vault,
+    deploy_hook,
+    user_deposit,
+    gov,
+    fish,
+    bunny,
+    doggie,
+    fish_amount,
+):
+    amount = fish_amount // 4
+    vault, hook = _vault_with_shares_and_hook(
+        asset, create_vault, deploy_hook, user_deposit, gov, fish, amount
+    )
+
+    with ape.reverts():
+        vault.transfer(ZERO_ADDRESS, amount, sender=fish)
+    with ape.reverts():
+        vault.transfer(vault.address, amount, sender=fish)
+    with ape.reverts("insufficient funds"):
+        vault.transfer(doggie.address, amount + 1, sender=fish)
+    with ape.reverts("insufficient allowance"):
+        vault.transferFrom(fish.address, doggie.address, amount, sender=bunny)
+
+    vault.approve(bunny.address, amount + 1, sender=fish)
+    with ape.reverts("insufficient funds"):
+        vault.transferFrom(fish.address, doggie.address, amount + 1, sender=bunny)
+
+    assert hook.post_transfer_count() == 0
+    assert vault.balanceOf(fish.address) == amount
+    assert vault.balanceOf(doggie.address) == 0
+
+
+def test_permit_then_transfer_from_reports_spender_as_caller(
+    asset,
+    create_vault,
+    deploy_hook,
+    sign_vault_permit,
+    gov,
+    fish,
+    bunny,
+    doggie,
+    fish_amount,
+):
+    amount = fish_amount // 5
+    owner = Account.create()
+    vault = create_vault(asset)
+    hook = deploy_hook()
+    asset.approve(vault.address, amount, sender=fish)
+    vault.deposit(amount, owner.address, sender=fish)
+    vault.set_transfer_hook(hook.address, sender=gov)
+
+    deadline = chain.pending_timestamp + 3600
+    signature = sign_vault_permit(
+        vault,
+        owner,
+        str(bunny.address),
+        allowance=amount,
+        deadline=deadline,
+    )
+    stale_signature = sign_vault_permit(
+        vault,
+        owner,
+        str(bunny.address),
+        allowance=amount,
+        deadline=deadline,
+        override_version="3.1.0",
+    )
+
+    with ape.reverts("invalid signature"):
+        vault.permit(
+            owner.address,
+            bunny.address,
+            amount,
+            deadline,
+            stale_signature.v,
+            stale_signature.r.to_bytes(32, byteorder="big"),
+            stale_signature.s.to_bytes(32, byteorder="big"),
+            sender=bunny,
+        )
+
+    assert vault.nonces(owner.address) == 0
+    vault.permit(
+        owner.address,
+        bunny.address,
+        amount,
+        deadline,
+        signature.v,
+        signature.r.to_bytes(32, byteorder="big"),
+        signature.s.to_bytes(32, byteorder="big"),
+        sender=bunny,
+    )
+
+    vault.transferFrom(owner.address, doggie.address, amount, sender=bunny)
+
+    assert hook.last_transfer_caller() == bunny.address
+    assert hook.last_transfer_sender() == owner.address
+    assert hook.last_transfer_receiver() == doggie.address
+    assert hook.last_transfer_shares() == amount
+    assert hook.last_transfer_allowance() == 0
+
+
+def test_erc4626_issue_and_burn_paths_do_not_call_transfer_hook(
+    asset,
+    create_vault,
+    deploy_hook,
+    gov,
+    fish,
+    bunny,
+    doggie,
+    fish_amount,
+):
+    amount = fish_amount // 8
+    vault = create_vault(asset)
+    hook = deploy_hook()
+    vault.set_transfer_hook(hook.address, sender=gov)
+    asset.mint(fish.address, amount * 2, sender=gov)
+    asset.approve(vault.address, amount * 2, sender=fish)
+
+    vault.deposit(amount, bunny.address, sender=fish)
+    vault.mint(amount, bunny.address, sender=fish)
+    vault.withdraw(amount, doggie.address, bunny.address, sender=bunny)
+    vault.redeem(amount, doggie.address, bunny.address, sender=bunny)
+
+    assert hook.post_transfer_count() == 0
+    assert vault.balanceOf(bunny.address) == 0
+    assert vault.totalSupply() == 0
+
+
+def test_report_fee_and_profit_lock_shares_do_not_call_transfer_hook(
+    asset,
+    create_vault,
+    create_strategy,
+    deploy_hook,
+    deploy_accountant,
+    set_fees_for_strategy,
+    user_deposit,
+    add_strategy_to_vault,
+    add_debt_to_strategy,
+    airdrop_asset,
+    gov,
+    fish,
+    fish_amount,
+):
+    amount = fish_amount // 10
+    gain = amount // 2
+    vault = create_vault(asset)
+    strategy = create_strategy(vault)
+    accountant = deploy_accountant(vault)
+    hook = deploy_hook()
+
+    user_deposit(fish, vault, asset, amount)
+    add_strategy_to_vault(gov, strategy, vault)
+    add_debt_to_strategy(gov, strategy, vault, amount)
+    set_fees_for_strategy(gov, strategy, accountant, 0, 5_000)
+    vault.set_transfer_hook(hook.address, sender=gov)
+
+    airdrop_asset(gov, asset, strategy, gain)
+    strategy.report(sender=gov)
+    vault.process_report(strategy.address, sender=gov)
+
+    assert vault.balanceOf(accountant.address) > 0
+    assert vault.balanceOf(vault.address) > 0
+    assert hook.post_transfer_count() == 0
+
+    vault.setProfitMaxUnlockTime(0, sender=gov)
+    assert hook.post_transfer_count() == 0
+
+
+@pytest.mark.parametrize("reentry_mode", [1, 2, 3])
+def test_post_transfer_same_vault_reentry_reverts_atomically(
+    reentry_mode,
+    asset,
+    create_vault,
+    deploy_hook,
+    user_deposit,
+    gov,
+    fish,
+    bunny,
+    doggie,
+    fish_amount,
+):
+    amount = fish_amount // 4
+    vault, hook = _vault_with_shares_and_hook(
+        asset, create_vault, deploy_hook, user_deposit, gov, fish, amount * 2
+    )
+    vault.approve(hook.address, amount, sender=fish)
+    hook.set_post_transfer_reentry(
+        reentry_mode,
+        fish.address,
+        doggie.address,
+        1,
+        sender=gov,
+    )
+
+    with ape.reverts():
+        vault.transfer(hook.address, amount, sender=fish)
+
+    assert vault.balanceOf(fish.address) == amount * 2
+    assert vault.balanceOf(hook.address) == 0
+    assert vault.balanceOf(doggie.address) == 0
+    assert vault.allowance(fish.address, hook.address) == amount
+    assert hook.post_transfer_count() == 0
+
+
+def test_shared_lock_blocks_transfer_from_deposit_hook_when_transfer_hook_unset(
+    asset,
+    create_vault,
+    deploy_hook,
+    gov,
+    fish,
+    bunny,
+    fish_amount,
+):
+    amount = fish_amount // 4
+    vault = create_vault(asset)
+    deposit_hook = deploy_hook()
+    vault.set_deposit_hook(deposit_hook.address, sender=gov)
+    deposit_hook.set_reenter_post_deposit(True, bunny.address, amount, sender=gov)
+    asset.approve(vault.address, amount, sender=fish)
+    fish_asset_balance = asset.balanceOf(fish.address)
+
+    assert vault.transfer_hook() == ZERO_ADDRESS
+    with ape.reverts():
+        vault.deposit(amount, deposit_hook.address, sender=fish)
+
+    assert deposit_hook.post_deposit_count() == 0
+    assert vault.balanceOf(deposit_hook.address) == 0
+    assert vault.balanceOf(bunny.address) == 0
+    assert vault.totalSupply() == 0
+    assert asset.balanceOf(fish.address) == fish_asset_balance
+
+
+def test_eoa_hook_bricks_transfers_until_cleared(
+    asset,
+    create_vault,
+    user_deposit,
+    gov,
+    fish,
+    bunny,
+    doggie,
+    fish_amount,
+):
+    amount = fish_amount // 4
+    vault = create_vault(asset)
+    user_deposit(fish, vault, asset, amount)
+    vault.set_transfer_hook(bunny.address, sender=gov)
+
+    with ape.reverts():
+        vault.transfer(doggie.address, amount, sender=fish)
+
+    assert vault.balanceOf(fish.address) == amount
+    assert vault.balanceOf(doggie.address) == 0
+
+    vault.set_transfer_hook(ZERO_ADDRESS, sender=gov)
+    vault.transfer(doggie.address, amount, sender=fish)
+    assert vault.balanceOf(fish.address) == 0
+    assert vault.balanceOf(doggie.address) == amount


### PR DESCRIPTION
## Description

Adds an optional post-transfer hook to Vault V3 share transfers.

- invokes `post_transfer(caller, sender, receiver, shares)` after balance, allowance, and event updates
- rolls back the full transfer when the hook reverts
- covers direct, delegated, zero-value, and self-transfers
- keeps mint and burn paths outside the transfer hook
- reuses `WITHDRAW_LIMIT_MANAGER`; no new role bit and `ALL` remains `16383`
- bumps the vault and factory API version to `3.1.1`
- keeps the hook active and configurable during pause and shutdown
- adds hook mocks, interfaces, documentation, and full behavioral coverage

All `transfer` and `transferFrom` calls now use the existing shared vault lock, even when no hook is configured. This adds about 4.5k gas and prevents share transfers from executing inside other locked same-vault flows. The hook itself runs under that lock and cannot reenter locked vault functions.

## Gas and size

- unset `transfer`: +4,478 gas against 3.1.0
- unset finite `transferFrom`: +4,466 gas
- configured no-op hook: +2,991 gas over unset
- runtime: 23,462 bytes, leaving 1,114 bytes below EIP-170

## Testing

- `ape test -q`: 362 passed
- `forge test`: 37 passed
- Vyper compile and Forge build pass
- changed Solidity interfaces pass Prettier and Solhint with no errors

## Checklist

- [x] I have run Vyper and Solidity linting
- [x] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have based the branch on the latest `master`
